### PR TITLE
Fix parsing of modules

### DIFF
--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -21,12 +21,21 @@ export default Ember.Controller.extend({
   }),
 
   moduleIDs: Ember.computed('model', function() {
-    return this.getRelationshipIDs('modules');
+    return this.getModuleRelationships(this.get('model.id'), 'modules');
   }),
 
   publicModuleIDs: Ember.computed('model', function() {
-    return this.getRelationshipIDs('public-modules');
+    return this.getModuleRelationships(this.get('model.id'), 'public-modules');
   }),
+
+  getModuleRelationships(versionId, moduleType) {
+    let relations = this.getRelations('public-modules');
+    return relations.map(id => id.substring(versionId.length + 1))
+  },
+
+  getRelations(relationship) {
+    return this.get('model').hasMany(relationship).ids().sort();
+  },
 
   getRelationshipIDs(relationship) {
     const classes = this.get('model').hasMany(relationship);

--- a/tests/acceptance/sidebar-nav-test.js
+++ b/tests/acceptance/sidebar-nav-test.js
@@ -15,10 +15,10 @@ test('can navigate to namespace from sidebar', function(assert) {
 
 test('can navigate to module from sidebar', function(assert) {
   visit('/ember/1.0.0');
-  click('.toc-level-1.modules a:contains(application)');
+  click('.toc-level-1.modules a:contains(ember-application)');
 
   andThen(() => {
-    assert.equal(currentURL(), '/ember/1.0.0/modules/application', 'navigated to module');
+    assert.equal(currentURL(), '/ember/1.0.0/modules/ember-application', 'navigated to module');
   });
 });
 

--- a/tests/unit/controllers/project-version-test.js
+++ b/tests/unit/controllers/project-version-test.js
@@ -1,0 +1,42 @@
+import { moduleFor, test } from 'ember-qunit';
+
+const moduleIds = [
+  "ember-2.10.0-ember",
+  "ember-2.10.0-ember-application",
+  "ember-2.10.0-ember-debug",
+  "ember-2.10.0-ember-extension-support",
+  "ember-2.10.0-ember-glimmer",
+  "ember-2.10.0-ember-htmlbars",
+  "ember-2.10.0-ember-metal",
+  "ember-2.10.0-ember-routing",
+  "ember-2.10.0-ember-runtime",
+  "ember-2.10.0-ember-testing",
+  "ember-2.10.0-ember-views"
+];
+
+const expectedModuleNames = [
+  "ember",
+  "ember-application",
+  "ember-debug",
+  "ember-extension-support",
+  "ember-glimmer",
+  "ember-htmlbars",
+  "ember-metal",
+  "ember-routing",
+  "ember-runtime",
+  "ember-testing",
+  "ember-views"
+];
+
+moduleFor('controller:project-version', 'Unit | Controller | project version');
+
+test('should render module names', function(assert) {
+  let controller = this.subject({
+    getRelations(relationship) {
+      return moduleIds;
+    }
+  });
+
+  let moduleNames = controller.getModuleRelationships('ember-2.10.1');
+  assert.deepEqual(moduleNames, expectedModuleNames);
+});


### PR DESCRIPTION
partially addresses #96. Shows modules as ember-* as the current api docs do.