### PR TITLE
Flush redis via npm script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ deploy:
     production: ember-api-docs
   api_key:
     secure: ZkKB+Ld1IokmJooZPGTZMA5L1KHBNg1qbC2KvebT9L2zTq0CEMjjzRfhmkivoG0riodz4M4rBr63UcqcnTLEoER/MU8kUt4f6gAdmi/WYCm/pxTx2vsxxwO26HFP90VDZ2yPlkYN2n+T/AYXittxRIKKBA1gxT8w9Cz4A39ojB+vpDnfhlybkes+0wpErgKgnF46eI7zz2fgbmIMqtUXgAsKey4wT4o6oqssOvEpVrtt9DX9KseDzelR6TsBafUPpYA8IMA5mqouN/HDmrY43S3a9W1SbXhvhFKads3sQO7VXIgdrbiu/clNvEaH7U9sLIW1vHnl17iQbVE2U2WibW3m6w9V/g0S96F1rDM6RZbiqgmhI5UXjVNrbmquAUE1Yxv0tVNzwq8KIZ0+4grzKwHJRDwI1Ri1J8QVBL5fQLVD669l9Hye1m6sli6VFLzGSBVYEC7fNTpk6TErgHjGsx/yThDl4QBzOitsmRzCxq3puloIUhF+aQ09T8G4OySq6wOgDwAbNFlMxDGmnglu3SXsu3xT74wOF8tLpdl4dk/DozYQQRyAFdpQHK+WHb5PswWifjEkypALCTdsZoehrzzxPPletNH9iXXMCW3c7jys5ad9RngJWy/Ka5mhk3bg5UAWvXnM3pWSGrOD2t36gq7k6FQVi7LF8BD9tD4GxxE=
+  run:
+    - "npm run heroku-flush-redis"
 
 env:
   global:

--- a/flush-redis.js
+++ b/flush-redis.js
@@ -1,0 +1,9 @@
+/* eslint node:true */
+const redisClient = require('redis').createClient(process.env.REDIS_URL);
+
+redisClient.once('ready', function () {
+  redisClient.flushall(function () {
+    console.log('Flushed redis cache');
+    redisClient.quit();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember test --launch=Firefox",
-    "heroku-postbuild": "bower install && rm -rf tmp/deploy-dist && ember deploy production && cd tmp/deploy-dist && npm install && cd ../.."
+    "heroku-postbuild": "bower install && rm -rf tmp/deploy-dist && ember deploy production && cd tmp/deploy-dist && npm install && cd ../..",
+    "heroku-flush-redis": "node flush-redis.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change allows for us to run a remote heroku command via cli to flush the redis cache. This will be used by ember-jsonapi-docs repo's travis script.

part of #67 