### PR TITLE
fix margin on tabbed layout

### DIFF
--- a/app/styles/components/_tabbed-layout.scss
+++ b/app/styles/components/_tabbed-layout.scss
@@ -21,7 +21,7 @@
       flex-grow: 1;
       text-align: center;
       padding: 0 0;
-      margin-bottom: 1em;
+      margin: 0 0 1em 0;
       border-top: solid 1px #fafafa;
       border-right: solid 1px #e6e4e3;
       border-left: 1px solid transparent;


### PR DESCRIPTION
Getting rid of the extra space above the tabs.

![image](https://cloud.githubusercontent.com/assets/3609063/21129326/d2fcbf1c-c0ce-11e6-8783-5c8d0b5d7687.png)

![image](https://cloud.githubusercontent.com/assets/3609063/21129374/07ec1bf0-c0cf-11e6-9396-c585cae1dba3.png)
