### PR TITLE
modules before namespaces

### DIFF
--- a/app/templates/components/table-of-contents.hbs
+++ b/app/templates/components/table-of-contents.hbs
@@ -1,15 +1,15 @@
 <ol class="toc-level-0">
-  <li class="toc-level-0"><a {{action 'toggle' 'namespaces'}} href="#">Namespaces</a>
-    <ol class="toc-level-1 namespaces" style="display: block">
-      {{#each namespaceIDs as |namespaceID|}}
-        <li class="toc-level-1">{{#link-to 'project-version.namespace' version namespaceID}}{{namespaceID}}{{/link-to}}</li>
-      {{/each}}
-    </ol>
-  </li>
   <li class="toc-level-0"><a {{action 'toggle' 'modules'}} href="#">Modules</a>
     <ol class="toc-level-1 modules" style="display: block">
       {{#each moduleIDs as |moduleID|}}
         <li class="toc-level-1">{{#link-to 'project-version.module' version moduleID}}{{moduleID}}{{/link-to}}</li>
+      {{/each}}
+    </ol>
+  </li>
+  <li class="toc-level-0"><a {{action 'toggle' 'namespaces'}} href="#">Namespaces</a>
+    <ol class="toc-level-1 namespaces" style="display: block">
+      {{#each namespaceIDs as |namespaceID|}}
+        <li class="toc-level-1">{{#link-to 'project-version.namespace' version namespaceID}}{{namespaceID}}{{/link-to}}</li>
       {{/each}}
     </ol>
   </li>


### PR DESCRIPTION
addresses #102 

switches the order of modules and namespaces to be consistent with the current api layout.