### PR TITLE
Consolidate namespace routes to the classes route

### DIFF
--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -29,7 +29,7 @@ export default Ember.Controller.extend({
   }),
 
   getModuleRelationships(versionId, moduleType) {
-    let relations = this.getRelations('public-modules');
+    let relations = this.getRelations(moduleType);
     return relations.map(id => id.substring(versionId.length + 1))
   },
 

--- a/app/controllers/project-version/module.js
+++ b/app/controllers/project-version/module.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import ClassController from './class';
+import _ from 'lodash/lodash';
 
 const { computed } = Ember;
 
@@ -14,5 +15,10 @@ export default ClassController.extend({
 
   classes: computed('model', function() {
     return Object.keys(this.get('model.classes'));
+  }),
+
+  classesAndNamespaces: computed('classes', 'namespaces', function () {
+    return _.uniq(_.union(this.get('namespaces'), this.get('classes')).sort(), true);
   })
+
 });

--- a/app/routes/project-version/class.js
+++ b/app/routes/project-version/class.js
@@ -25,14 +25,15 @@ export default Ember.Route.extend({
 
   find(typeName, param) {
     return this.store.find(typeName, param).catch(() => {
-      return this.transitionTo('project-version'); // class doesn't exist in new version
+      return this.store.find('namespace', param).catch(() => {
+        return this.transitionTo('project-version'); // class doesn't exist in new version
+      });
     });
   },
 
   afterModel(klass) {
     set(this, 'headData.description', klass.get('ogDescription'));
     const relationships = get(klass.constructor, 'relationshipNames');
-
     const promises = Object.keys(relationships).reduce((memo, relationshipType) => {
       const relationshipPromises = relationships[relationshipType].map(name => klass.get(name));
       return memo.concat(relationshipPromises);

--- a/app/templates/components/table-of-contents.hbs
+++ b/app/templates/components/table-of-contents.hbs
@@ -9,7 +9,7 @@
   <li class="toc-level-0"><a {{action 'toggle' 'namespaces'}} href="#">Namespaces</a>
     <ol class="toc-level-1 namespaces" style="display: block">
       {{#each namespaceIDs as |namespaceID|}}
-        <li class="toc-level-1">{{#link-to 'project-version.namespace' version namespaceID}}{{namespaceID}}{{/link-to}}</li>
+        <li class="toc-level-1">{{#link-to 'project-version.class' version namespaceID}}{{namespaceID}}{{/link-to}}</li>
       {{/each}}
     </ol>
   </li>

--- a/app/templates/project-version/module.hbs
+++ b/app/templates/project-version/module.hbs
@@ -18,33 +18,18 @@
     </section>
   {{/if}}
 
-  {{#if namespaces}}
+  {{#if classesAndNamespaces}}
     <section>
-      <h2>Namespaces</h2>
-        <ul class="spec-property-list">
-          {{#each namespaces as |namespace|}}
-            <li>
-              {{#link-to 'project-version.namespace' namespace}}
-                {{namespace}}
-              {{/link-to}}
-            </li>
-          {{/each}}
-        </ul>
-    </section>
-  {{/if}}
-
-  {{#if classes}}
-    <section>
-      <h2>Classes</h2>
-        <ul class="spec-event-list">
-          {{#each classes as |klass|}}
-            <li>
-              {{#link-to 'project-version.class' klass}}
-                {{klass}}
-              {{/link-to}}
-            </li>
-          {{/each}}
-        </ul>
+      <h2>Classes and Namespaces</h2>
+      <ul class="spec-property-list">
+        {{#each classesAndNamespaces as |klass|}}
+          <li>
+            {{#link-to 'project-version.class' klass}}
+              {{klass}}
+            {{/link-to}}
+          </li>
+        {{/each}}
+      </ul>
     </section>
   {{/if}}
 

--- a/tests/acceptance/sidebar-nav-test.js
+++ b/tests/acceptance/sidebar-nav-test.js
@@ -9,7 +9,7 @@ test('can navigate to namespace from sidebar', function(assert) {
   click('.toc-level-1.namespaces a:contains(Ember.String)');
 
   andThen(() => {
-    assert.equal(currentURL(), '/ember/1.0.0/namespaces/Ember.String', 'navigated to namespace');
+    assert.equal(currentURL(), '/ember/1.0.0/classes/Ember.String', 'navigated to namespace');
   });
 });
 


### PR DESCRIPTION
Addresses #96 by making the linking behavior the same as it currently is at https://emberjs.com/api

In a submodule, classes and namespaces will now show up in a common, sorted section called "Classes and Namespaces" (as opposed to separate sections as previously)

![image](https://cloud.githubusercontent.com/assets/3609063/22576978/f1a06914-e98c-11e6-9869-c8be356683cc.png)

Current App:
![image](https://cloud.githubusercontent.com/assets/3609063/22601308/5ba7fbea-ea0c-11e6-9fb0-ac9ec573393b.png)

_(in our new version its at least sorted)_

All classes and namespaces will be addressable under /ember/<version>/classes/<class name>, both from submodule details, and from the left nav.

To support separation of classes and namespaces, we'll need to do some work on how namespaces and classes are identified within a submodule in the yuidoc, likely requiring changes to the ember code documentation.  This is a bit bigger issue than what we want to tackle at this point, so the decision was made in the last learn team meeting to go for the same routing behavior as what is already there, that being all classes and namespaces routable under 'classes'.