### PR TITLE
Add parent link to modules

### DIFF
--- a/app/models/module.js
+++ b/app/models/module.js
@@ -6,5 +6,6 @@ const { attr } = DS;
 export default ClassModel.extend({
   submodules: attr(),
   classes: attr(),
-  namespaces: attr()
+  namespaces: attr(),
+  parent: attr()
 });

--- a/app/templates/project-version/module.hbs
+++ b/app/templates/project-version/module.hbs
@@ -1,6 +1,15 @@
 <article class="chapter">
   <h1>{{model.name}} {{#if model.access}}<span class="access">{{model.access}}</span>{{/if}}</h1>
 
+  <p class="attributes">
+    {{#if model.parent}}
+      <div class="attribute">
+        <span class="attribute-label">Parent:</span>
+        <span class="attribute-value">{{#link-to 'project-version.module' model.projectVersion.version model.parent}}{{model.parent}}{{/link-to}}</span>
+      </div>
+    {{/if}}
+  </p>
+
   <p>{{{model.description}}}</p>
 
   {{#if submodules}}

--- a/tests/acceptance/module-test.js
+++ b/tests/acceptance/module-test.js
@@ -1,0 +1,47 @@
+import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
+import { test } from 'qunit';
+
+moduleForAcceptance('Acceptance | Module');
+
+test('lists all classes and namespaces on the module page', function(assert) {
+
+  visit('ember/1.0.0/modules/ember-application');
+
+  andThen(() => {
+    const store = this.application.__container__.lookup('service:store');
+    const container = store.peekRecord('module', 'ember-1.0.0-ember-application');
+
+    let numberNameSpaces = Object.keys(container.get('namespaces')).length;
+    let numberClasses = Object.keys(container.get('classes')).length;
+
+    assert.equal(find('.spec-property-list li').length, numberClasses + numberNameSpaces);
+  });
+
+});
+
+test('lists all submodules on the module page', function(assert) {
+
+  visit('ember/1.0.0/modules/ember');
+
+  andThen(() => {
+    const store = this.application.__container__.lookup('service:store');
+    const container = store.peekRecord('module', 'ember-1.0.0-ember');
+
+    let numberSubModules = Object.keys(container.get('submodules')).length;
+
+    assert.equal(find('.spec-method-list li').length, numberSubModules);
+  });
+
+});
+
+test('display submodule parent', function(assert) {
+
+  visit('ember/1.0.0/modules/ember-application');
+
+  andThen(() => {
+    const store = this.application.__container__.lookup('service:store');
+    const container = store.peekRecord('module', 'ember-1.0.0-ember-application');
+
+    assert.ok(find(`.attribute-value:contains(${container.get('parent')})`).length);
+  });
+});


### PR DESCRIPTION
Addresses #104, display submodule parent.

Depends on https://github.com/ember-learn/ember-jsonapi-docs/pull/20

![image](https://cloud.githubusercontent.com/assets/1313472/23337256/913e249c-fbbd-11e6-8f25-72aa85080b9c.png)
