### PR TITLE
Mobile layout adjustments

### DIFF
--- a/app/styles/_class.scss
+++ b/app/styles/_class.scss
@@ -24,6 +24,7 @@ article.chapter {
 
 .access-checkbox {
   display: inline;
+  white-space: nowrap;
 }
 
 .attributes {

--- a/app/styles/_class.scss
+++ b/app/styles/_class.scss
@@ -36,6 +36,11 @@ article.chapter {
     color: $black;
     font-weight: bold;
     text-transform: uppercase;
+
+    @media (max-width: $mobile-portrait-screen){
+      display: block;
+      margin-top: 10px;
+    }
   }
 
   .attribute-value {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -25,20 +25,11 @@ body {
       padding: 15px;
     }
 
-    .sidebar {
-      position: fixed;
-      bottom: 0;
-      top: 80px;
-      left: 0;
-      overflow:auto;
-      width: 400px;
-    }
-
     .content {
       position:fixed;
       left: 400px;
       right: 0;
-      top: 80px;
+      top: $top-spacing;
       bottom: 0;
       overflow:auto;
 
@@ -46,7 +37,10 @@ body {
         max-width: 800px;
         margin: 0 auto;
       }
+
+        @media (min-width:$large-screen) and (max-width: 1200px){
+          left: 300px;
+        }
     }
   }
-
 }

--- a/app/styles/base/_grid-settings.scss
+++ b/app/styles/base/_grid-settings.scss
@@ -9,6 +9,7 @@
 // Neat Breakpoints
 $medium-screen: 40em; // 640px
 $large-screen: 54em; // 864px
+$mobile-portrait-screen: 30em; // 480px
 
 $medium-screen-up: new-breakpoint(min-width $medium-screen 4);
 $large-screen-up: new-breakpoint(min-width $large-screen 8);

--- a/app/styles/base/_lists.scss
+++ b/app/styles/base/_lists.scss
@@ -8,6 +8,10 @@ ol {
     list-style-type: disc;
     margin-bottom: $small-spacing;
     padding-left: $base-spacing;
+
+    @media (max-width: $mobile-portrait-screen){
+      padding-left: 0;
+    }
   }
 
   &%default-ol {

--- a/app/styles/base/_variables.scss
+++ b/app/styles/base/_variables.scss
@@ -14,9 +14,10 @@ $base-line-height: 1.5;
 $heading-line-height: 1.2;
 
 // Spacing
-$base-spacing: $base-line-height * 1em;
-$small-spacing: $base-spacing / 2;
-$large-spacing: $base-spacing * 2;
+$base-spacing: $base-line-height * 1em; // 24px
+$small-spacing: $base-spacing / 2; // 12px
+$large-spacing: $base-spacing * 2; // 48px
+$top-spacing: $base-spacing * 3.333; // 80px
 
 // Colors
 $ember-orange: #dd6a58;

--- a/app/styles/components/_article.scss
+++ b/app/styles/components/_article.scss
@@ -1,5 +1,9 @@
 article {
-  padding: $large-spacing;
+  padding: $large-spacing $small-spacing;
+
+  @media (min-width: $large-screen){
+    padding: 0 $small-spacing;
+  }
 
   .edit-page {
     @include size(24px 18px);

--- a/app/styles/components/_article.scss
+++ b/app/styles/components/_article.scss
@@ -5,6 +5,10 @@ article {
     padding: 0 $small-spacing;
   }
 
+  @media (max-width: $mobile-portrait-screen){
+    padding: $large-spacing 0;
+  }
+
   .edit-page {
     @include size(24px 18px);
     color: $brown;

--- a/app/styles/components/_class-field-desc.scss
+++ b/app/styles/components/_class-field-desc.scss
@@ -1,5 +1,9 @@
 .chapter li {
   margin: $small-spacing 0;
+
+  @media (max-width: $mobile-portrait-screen){
+    margin: 0;
+  }
 }
 .chapter ul + .highlight {
   margin-top: $base-spacing;

--- a/app/styles/components/_sidebar.scss
+++ b/app/styles/components/_sidebar.scss
@@ -3,6 +3,7 @@
   border-bottom: $base-border;
   position: relative;
   z-index: 1;
+  padding: $small-spacing 0;
 
   @include media($large-screen) {
     @include span-columns(3.5);
@@ -17,6 +18,19 @@
       background-color: $sidebar-background-color;
       z-index: -1;
     }
+  }
+
+  @include media($large-screen-up) {
+    position: fixed;
+    bottom: 0;
+    top: $top-spacing;
+    left: 0;
+    overflow:auto;
+    width: 400px;
+  }
+
+  @media (min-width:$large-screen) and (max-width: 1200px){
+    width: 300px;
   }
 
   .select2 {

--- a/app/styles/components/_tabbed-layout.scss
+++ b/app/styles/components/_tabbed-layout.scss
@@ -4,8 +4,17 @@
   border-radius: 5px;
   overflow: hidden;
 
+  @media (max-width: $mobile-portrait-screen){
+    border: 0;
+    border-radius: 0;
+  }
+
   .api-index-filter, section {
     padding: 0 1em;
+
+    @media (max-width: $mobile-portrait-screen){
+      padding: 0;
+    }
   }
 
   .tabbed-layout__menu {
@@ -16,7 +25,7 @@
     margin: 0 0;
     padding: 0 0;
 
-    .tabbed-layout__menu__item {
+    &__item {
       cursor: pointer;
       flex-grow: 1;
       text-align: center;
@@ -47,7 +56,7 @@
 
     }
 
-    .tabbed-layout__menu__item_selected {
+    &__item_selected {
       background-image: linear-gradient(0deg, #e7624b, #f67862);
       color: white;
       border-right: 1px solid #f67862;
@@ -57,6 +66,15 @@
         background-image: linear-gradient(0deg, #e7624b, #f67862);
         color: white;
         border-bottom: none;
+      }
+    }
+
+    &__item, &__item_selected {
+      &, &:first-of-type {
+        @media (max-width: $mobile-portrait-screen){
+          border: 0;
+          border-radius: 0;
+        }
       }
     }
   }

--- a/app/styles/components/_tabbed-layout.scss
+++ b/app/styles/components/_tabbed-layout.scss
@@ -21,15 +21,12 @@
     display: flex;
     list-style-type: none;
     overflow: hidden;
-    border-bottom: solid 1px e6e4e3;
     margin: 0 0;
     padding: 0 0;
 
     &__item {
       cursor: pointer;
       flex-grow: 1;
-      text-align: center;
-      padding: 0 0;
       margin: 0 0 1em 0;
       border-top: solid 1px #fafafa;
       border-right: solid 1px #e6e4e3;
@@ -40,8 +37,6 @@
       text-align: center;
       font-weight: normal;
       color: #443331;
-      font-family: 'Helvetica Neue';
-      width: 100%;
 
       &:hover {
         background-color: #ebebeb;
@@ -69,11 +64,17 @@
       }
     }
 
-    &__item, &__item_selected {
-      &, &:first-of-type {
-        @media (max-width: $mobile-portrait-screen){
+    @media (max-width: $mobile-portrait-screen){
+      &__item, &__item_selected {
+        &, &:first-of-type {
           border: 0;
           border-radius: 0;
+          padding-left: 0;
+          padding-right: 0;
+        }
+
+        &:not(:last-of-type){
+          border-right: solid 1px #e6e4e3;
         }
       }
     }


### PR DESCRIPTION
This removes extra paddings and margins on mobile and sometimes medium resolutions to fit more content screen.

Also, some elements are wrapped beneath each other.

Grey border for "tabbed layout" has been removed to prevent double paddings and to have more space.

There was also an issue when Events, Properties etc. did not fit into the 320px mobile screen.

![screen shot 2017-03-16 at 18 22 03](https://cloud.githubusercontent.com/assets/9468793/24009521/882bd4be-0a75-11e7-9ee1-20253cd212d1.png)
![screen shot 2017-03-16 at 18 21 50](https://cloud.githubusercontent.com/assets/9468793/24009525/8c8dfa5a-0a75-11e7-977a-bc387003e032.png)
