### PR TITLE
Add router root url for nginx redirections to work

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -3,7 +3,7 @@ import config from './config/environment';
 
 const Router = Ember.Router.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.routerRootURL
 });
 
 Router.map(function() {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'ember-api-docs',
     environment: environment,
     rootURL: '/',
+    routerRootURL: '/',
     locationType: 'auto',
     IS_FASTBOOT: !!process.env.EMBER_CLI_FASTBOOT,
     EmberENV: {
@@ -57,6 +58,14 @@ module.exports = function(environment) {
     ENV.contentSecurityPolicy = {
       "connect-src": "'self' http://localhost:5984 https://*.cloudant.com"
     };
+
+    /**
+     * Ideally we want this to be only for fast boot. But we have to wait for
+     * https://github.com/ember-fastboot/ember-cli-fastboot/issues/254 to be
+     * solved for that
+     */
+    ENV.routerRootURL = '/api-new/';
+
   }
 
   return ENV;


### PR DESCRIPTION
This enables us to have our fastboot app work both in standalone & proxy mode in production environment