### PR TITLE
Add queryParam support for show entities

### DIFF
--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 import _ from 'lodash/lodash';
 import semverCompare from 'npm:semver-compare';
 import getMinorVersion from "../utils/get-minor-version";
+import FilterParams from '../mixins/filter-params';
 
 const { Controller, computed, A, inject } = Ember;
 
-export default Controller.extend({
+export default Controller.extend(FilterParams, {
 
   filterData: inject.service(),
   showPrivateClasses: computed.alias('filterData.sideNav.showPrivate'),

--- a/app/mixins/filter-params.js
+++ b/app/mixins/filter-params.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+const {
+  Mixin, get, set, computed, A,
+  String: { capitalize, w },
+  inject: { service }
+} = Ember;
+
+export default Mixin.create({
+  filterData: service(),
+
+  queryParams: [{visibilityFilter: 'show'}],
+
+  visibilityFilter: computed(
+    'filterData.{showInherited,showProtected,showPrivate,showDeprecated}',
+    {
+      get() {
+        return A([
+          get(this, 'filterData.showInherited') ? 'inherited' : null,
+          get(this, 'filterData.showProtected') ? 'protected' : null,
+          get(this, 'filterData.showPrivate') ? 'private' : null,
+          get(this, 'filterData.showDeprecated') ? 'deprecated' : null
+        ]).compact().join(',');
+      },
+      set(key, value = '') {
+        let filters = A(value.split(','));
+        w('inherited protected private deprecated')
+          .forEach(filter => {
+            let enabled = filters.includes(filter);
+            set(this, `filterData.show${capitalize(filter)}`, enabled);
+          });
+        return value;
+      }
+    }
+  )
+});

--- a/tests/acceptance/class-test.js
+++ b/tests/acceptance/class-test.js
@@ -37,3 +37,11 @@ test('lists all the events on the class page', function (assert) {
   const container = store.peekRecord('class', 'ember-1.0.0-Container');
   assert.equal($(find('.spec-event-list li')).length, container.get('events.length'));
 });
+
+test('has query params for access visibilities', function (assert) {
+  let params = (currentURL().match(/show=([\w\d%]*)/)[1] || '').split('%2C');
+  assert.ok(params.includes('inherited'), 'show param includes inherited');
+  assert.ok(params.includes('protected'), 'show param includes protected');
+  assert.ok(params.includes('private'), 'show param includes private');
+  assert.ok(params.includes('deprecated'), 'show param includes deprecated');
+});

--- a/tests/acceptance/tab-nav-test.js
+++ b/tests/acceptance/tab-nav-test.js
@@ -2,6 +2,10 @@ import { test } from 'qunit';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
+function currentURLNoParams() {
+  return currentURL().replace(/\?.*$/, '');
+}
+
 moduleForAcceptance('Acceptance | tab navigation');
 
 test('switching tabs', function(assert) {
@@ -10,28 +14,28 @@ test('switching tabs', function(assert) {
   click('.tabbed-layout__menu li:contains(Methods)');
 
   andThen(() => {
-    assert.equal(currentURL(), '/ember/1.0.0/classes/Ember.Component/methods?anchor=', 'navigated to methods');
+    assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component/methods', 'navigated to methods');
     assert.ok(find('.tabbed-layout__menu li:contains(Methods)').hasClass('tabbed-layout__menu__item_selected'), 'methods tab selected');
   });
 
   click('.tabbed-layout__menu li:contains(Properties)');
 
   andThen(() => {
-    assert.equal(currentURL(), '/ember/1.0.0/classes/Ember.Component/properties?anchor=', 'navigated to properties');
+    assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component/properties', 'navigated to properties');
     assert.ok(find('.tabbed-layout__menu li:contains(Properties)').hasClass('tabbed-layout__menu__item_selected'), 'properties tab selected');
   });
 
   click('.tabbed-layout__menu li:contains(Events)');
 
   andThen(() => {
-    assert.equal(currentURL(), '/ember/1.0.0/classes/Ember.Component/events?anchor=', 'navigated to events');
+    assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component/events', 'navigated to events');
     assert.ok(find('.tabbed-layout__menu li:contains(Events)').hasClass('tabbed-layout__menu__item_selected'), 'events tab selected');
   });
 
   click('.tabbed-layout__menu li:contains(Index)');
 
   andThen(() => {
-    assert.equal(currentURL(), '/ember/1.0.0/classes/Ember.Component', 'navigated to index');
+    assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component', 'navigated to index');
     assert.ok(find('.tabbed-layout__menu li:contains(Index)').hasClass('tabbed-layout__menu__item_selected'), 'index tab selected');
   });
 });


### PR DESCRIPTION
Adds a mixin that will translate the filterData properties into a comma separated queryParam (show=). At the moment it is used by the project-version controller since it is the parent of all the controllers that would need the filterData. It is started as a mixin because I thought it had to be part of each controller but (Ember being cool) it can also work in one spot in the parent hierarchy. I left it as a mixin simple because the project-version controller is almost 100 lines large so far.

I aded one test to see the query params show up when you click the check boxes. I also had to fix some tests that had to brittle expectations of the URL. I simply stripped out the query params from the URL since the tests were not asserting anything regarding params.

Closes #148