### PR TITLE
add css tooltip to github link

### DIFF
--- a/app/styles/_class.scss
+++ b/app/styles/_class.scss
@@ -3,6 +3,54 @@ article.chapter {
     float:right;
     width: 24px;
     height: 24px;
+    display: block;
+    position: relative;
+
+    @media (min-width: $mobile-portrait-screen + 1){
+      &::before, &::after {
+        transition: 0.2s opacity, 0.2s transform;
+      }
+
+      &::before {
+        opacity: 0;
+        position: absolute;
+        content: '';
+        width: 10px;
+        height: 10px;
+        left: -20px;
+        bottom: 5px;
+        background: gray;
+        transform: rotate(-45deg) translateX(-5px) translateY(-5px);
+        transform-origin: 50% 50%;
+      }
+
+      &::after {
+        opacity: 0;
+        position: absolute;
+        bottom: -4px;
+        left: -140px;
+        width: 125px;
+        content: attr(data-tooltip);
+        padding: 2px 0px;
+        text-align: center;
+        background: gray;
+        color: white;
+        transform: translateX(-10px);
+      }
+
+      &:hover {
+        &::before {
+          opacity: 1;
+          transform: rotate(-45deg) translateY(0px);
+        }
+
+        &::after {
+          opacity: 1;
+          transform: translateX(0px);
+        }
+      }
+    }
+
   }
 
   .api__index__content {

--- a/app/styles/_class.scss
+++ b/app/styles/_class.scss
@@ -36,6 +36,7 @@ article.chapter {
         background: gray;
         color: white;
         transform: translateX(-10px);
+        border-radius: 3px;
       }
 
       &:hover {

--- a/app/templates/project-version/class.hbs
+++ b/app/templates/project-version/class.hbs
@@ -1,5 +1,5 @@
 <article class="chapter">
-  <a class="heading__link__edit" href="{{github-link model.project.id model.projectVersion.version model.file model.line}}" target="_blank" rel="noopener">{{partial "svg/fa-pencil"}}</a>
+  <a data-tooltip="Edit on Github" class="heading__link__edit" href="{{github-link model.project.id model.projectVersion.version model.file model.line}}" target="_blank" rel="noopener">{{partial "svg/fa-pencil"}}</a>
   <h1>
     {{model.name}} {{#if model.access}}<span class="access">{{model.access}}</span>{{/if}}
   </h1>


### PR DESCRIPTION
Adds a tooltip via CSS that shows up on hover. Since it's hover, it's a solution for desktop only.

![screen shot 2017-03-17 at 21 52 22](https://cloud.githubusercontent.com/assets/9468793/24062541/4a316664-0b5c-11e7-9472-28a881b5263f.png)
