### PR TITLE
Update typography and responsive styles

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,16 +6,13 @@
     <title>Ember API Documentation</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- <link rel="stylesheet" href="https://use.typekit.net/c/a9d5ec/1w;anonymous-pro,7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191,SC9:W:n4;proxima-nova,7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191,2clzCG:W:i4,2clzCK:W:n1,2clzC9:W:n3,2clzCF:W:n4,2clzC5:W:n7;proxima-nova-soft,7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191,gDX:W:n4,gDY:W:n5,gDb:W:n7/l?3bb2a6e53c9684ffdc9a9bf4135b2a625d2f4b913c6083f29a4114d89bb4e3dea5f1cb97ea3d768ce01df6bd96bbbcbe8d540583ae937ac8ffe81181aea45f4e5d9c74280191fdea33de8413e7e5eccb3e6021d2d35f421911556cc04ff84c5e973770f974f9f4f3f588e61961e46a5832fee4a2be64bf697425c141e196f93e76" media="all"> -->
     <link rel="shortcut icon" href="{{rootURL}}assets/images/favicon.png">
-
-    <!-- This TypeKit account is managed by @wifelette. Contact her with any issues. -->
-    <!-- <script src="https://use.typekit.net/stz3kpn.js"></script> -->
 
     {{content-for "head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ember-api-docs.css">
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet">
 
     {{content-for "head-footer"}}
   </head>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -2,7 +2,6 @@
 @import "./base/base";
 @import "neat";
 @import "./components/all";
-
 @import "class";
 
 body {
@@ -10,9 +9,7 @@ body {
   width: 100%;
 }
 
-
-@include media($large-screen-up) {
-
+@include media($medium-large-screen-up) {
   .header {
     position: fixed;
     width: 100%;
@@ -20,27 +17,25 @@ body {
 
   main.container {
     width: 100%;
+  }
 
-    > * {
-      padding: 15px;
-    }
+  main.container .content {
+    position: fixed;
+    left: 400px;
+    right: 0;
+    top: $top-spacing;
+    bottom: 0;
+    overflow:auto;
+    padding: $base-spacing;
 
-    .content {
-      position:fixed;
-      left: 400px;
-      right: 0;
-      top: $top-spacing;
-      bottom: 0;
-      overflow:auto;
-
-      .chapter {
-        max-width: 800px;
-        margin: 0 auto;
-      }
-
-        @media (min-width:$large-screen) and (max-width: 1200px){
-          left: 300px;
-        }
+    @media (min-width: $medium-screen) and (max-width: 1200px) {
+      left: 300px;
     }
   }
+
+  main.container .content .chapter {
+    max-width: 800px;
+    margin: 0 auto;
+  }
 }
+

--- a/app/styles/base/_grid-settings.scss
+++ b/app/styles/base/_grid-settings.scss
@@ -7,9 +7,10 @@
 // $max-width: 1088px;
 
 // Neat Breakpoints
-$medium-screen: 40em; // 640px
-$large-screen: 54em; // 864px
-$mobile-portrait-screen: 30em; // 480px
+$mobile-portrait-screen: em(480);
+$medium-screen: em(640);
+$large-screen: em(860);
 
 $medium-screen-up: new-breakpoint(min-width $medium-screen 4);
+$medium-large-screen-up: new-breakpoint(min-width $medium-screen 8);
 $large-screen-up: new-breakpoint(min-width $large-screen 8);

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -1,13 +1,13 @@
 @import "mixins/hidpi";
 
 body {
-  font-feature-settings: "kern", "liga", "pnum";
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;
   line-height: $base-line-height;
+  font-feature-settings: "kern", "liga", "pnum";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1,

--- a/app/styles/base/_variables.scss
+++ b/app/styles/base/_variables.scss
@@ -1,8 +1,7 @@
 // Typography
-$base-font-family: $helvetica;
+$base-font-family: 'Source Sans Pro', sans-serif;
 $heading-font-family: $base-font-family;
 $monospace-font-family: Menlo, Courier, monospace;
-$footer-font-family: proxima-nova, sans-serif;
 
 // Font Sizes
 $base-font-size: 1rem;

--- a/app/styles/components/_article.scss
+++ b/app/styles/components/_article.scss
@@ -1,12 +1,8 @@
 article {
   padding: $large-spacing $small-spacing;
 
-  @media (min-width: $large-screen){
-    padding: 0 $small-spacing;
-  }
-
-  @media (max-width: $mobile-portrait-screen){
-    padding: $large-spacing 0;
+  @media (min-width: $medium-screen){
+    padding: $small-spacing;
   }
 
   .edit-page {

--- a/app/styles/components/_footer.scss
+++ b/app/styles/components/_footer.scss
@@ -2,7 +2,6 @@
   background-color: shade($creme, 3%);
   border-top: 1px solid $linen;
   text-align: center;
-  font-family: $footer-font-family;
 
   .container {
     @include padding(2em 1em);

--- a/app/styles/components/_header.scss
+++ b/app/styles/components/_header.scss
@@ -5,13 +5,13 @@
   padding: 1em 0;
 
   .container {
-    @include media($large-screen) {
+    @include media($medium-large-screen-up) {
       display: flex;
     }
   }
 
   .header-nav {
-    @include media($large-screen) {
+    @include media($medium-large-screen-up) {
       align-items: center;
       display: flex;
       height: 2.8em;
@@ -29,7 +29,7 @@
     @include margin(10px null);
     text-align: center;
 
-    @include media($large-screen) {
+    @include media($medium-large-screen-up) {
       flex: 1 0 0;
       display: inline-block;
     }
@@ -56,12 +56,14 @@
   }
 }
 
-.header-logo {
-  a {
-    @include size(100px 40px);
-    background: url("/assets/images/ember-logo.svg") no-repeat;
-    display: block;
-    margin: -15px auto 0 0;
+.header-logo a {
+  @include size(100px 40px);
+  background: url("/assets/images/ember-logo.svg") no-repeat;
+  display: block;
+  margin: -10px auto 0; // optical center
+
+  @include media($large-screen) {
+    margin-top: -6px;
   }
 }
 

--- a/app/styles/components/_sidebar.scss
+++ b/app/styles/components/_sidebar.scss
@@ -5,11 +5,19 @@
   z-index: 1;
   padding: $small-spacing 0;
 
-  @include media($large-screen) {
+  @include media($medium-large-screen-up) {
+    // fixed sidebar, full height
     @include span-columns(3.5);
+    margin-right: 0;
+    position: fixed;
+    bottom: 0;
+    top: $top-spacing;
+    left: 0;
+    width: 19em;
+    overflow: auto;
     border-bottom: 0;
     border-right: $base-border;
-    padding: $large-spacing $gutter $large-spacing 0;
+    padding: $small-spacing $base-spacing;
 
     &::before {
       @include position(absolute, 0 0 0 -100vw);
@@ -20,27 +28,12 @@
     }
   }
 
-  @include media($large-screen-up) {
-    position: fixed;
-    bottom: 0;
-    top: $top-spacing;
-    left: 0;
-    overflow:auto;
-    width: 400px;
-  }
-
-  @media (min-width:$large-screen) and (max-width: 1200px){
-    width: 300px;
+  @media (min-width: 1200px) {
+    width: 22em;
   }
 
   .select2 {
     margin-bottom: 1em;
-  }
-  ol {
-    margin-bottom: 1.5em;
-  }
-  div {
-    padding-bottom: 3em;
   }
 }
 
@@ -108,7 +101,8 @@ li.toc-level-0 {
     color: $brown;
     display: block;
     line-height: 1.25;
-    padding: 0.33em 0;
+    padding-top: 0.25em;
+    padding-bottom: 0.25em;
 
     &:hover {
       color: $ember-orange;
@@ -121,7 +115,6 @@ li.toc-level-0 {
 
   > a {
     font-weight: bold;
-    margin: 0.33em 0;
   }
 }
 
@@ -149,6 +142,6 @@ ol.toc-level-1 {
   }
 
   a {
-    padding-left: $gutter;
+    padding-left: $small-spacing;
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -31,9 +31,9 @@ module.exports = function(environment) {
     ENV.contentSecurityPolicy = {
       "connect-src": "'self' http://localhost:5984 https://*.cloudant.com",
       "script-src": "'self' unsafe-inline use.typekit.net",
-      "font-src": "'self' data://* use.typekit.net",
-      "img-src": "'self' p.typekit.net",
-      "style-src": "'self' 'unsafe-inline' https://use.typekit.net"
+      "font-src": "'self' data://* https://fonts.gstatic.com",
+      "img-src": "'self'",
+      "style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com"
     };
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;


### PR DESCRIPTION
Hi, this PR changes the typography to use 'Source Sans Pro' in order to match the Ember.js website and tweaks the responsive styles to keep the navigation in one-row and the fixed sidebar down to 640px.

I also made the sidebar typography a bit tighter.

Ideally, we'd have a burger navigation on mobile, perhaps even on tablet, but that's for another time :)

Before:

![before](https://cloud.githubusercontent.com/assets/184567/24123535/28c515a0-0dc0-11e7-85f5-03e17a57e336.png)

After:

![after](https://cloud.githubusercontent.com/assets/184567/24123534/28c3a328-0dc0-11e7-93e4-fbc6aac4806f.png)