### PR TITLE
Set root url for service worker in prod

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,14 +2,14 @@
 <html manifest="{{rootURL}}manifest.appcache" lang="en">
   <head>
     <script type='text/javascript'>
-     window.addEventListener('load', function(e) {
-       window.applicationCache.addEventListener('updateready', function(e) {
-         if (window.applicationCache.status == window.applicationCache.UPDATEREADY) {
+       window.addEventListener('load', function(e) {
+         window.applicationCache.addEventListener('updateready', function(e) {
+           if (window.applicationCache.status == window.applicationCache.UPDATEREADY) {
              window.applicationCache.swapCache();
              window.location.reload();
-         }
+           }
+         }, false);
        }, false);
-     }, false);
     </script>
 
     <meta charset="utf-8">

--- a/config/environment.js
+++ b/config/environment.js
@@ -72,6 +72,7 @@ module.exports = function(environment) {
     ENV.routerRootURL = '/api-new/';
 
   }
+
   ENV.manifest = {
     enabled: true,
     appcacheFile: "/manifest.appcache",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,6 +29,12 @@ module.exports = function(defaults) {
     }
   });
 
+  if (app.env === 'production') {
+    app.options['ember-cli-service-worker'] = {
+      rootUrl: '/api-new/'
+    }
+  }
+
   if (!process.env.EMBER_CLI_FASTBOOT) {
     app.import(app.bowerDirectory + '/jquery-scrollparent/jquery.scrollparent.js');
   }


### PR DESCRIPTION
so when we are deployed at emberjs.com/api-new/, we are looking for sw-registration.js at the root (emberjs.com/).  We should look instead at /api-new/