### PR TITLE
Cheat fastboot to believe we're on ssl

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,25 @@
 import Ember from 'ember';
+import ENV from 'ember-api-docs/config/environment';
+
+
+const { inject: { service } } = Ember;
 
 export default Ember.Route.extend({
+
+  fastboot: service(),
+
   beforeModel() {
+    let fastboot = this.get('fastboot');
+
+    // This app doesn't get its own custom domain since its part of emberjs.com site
+    // under the `/api/` path. Since there's no custom domain or ssl keys to
+    // setup, we're convincing the fastboot server into believing we're serving over ssl.
+    if (fastboot.get('isFastBoot') && ENV.environment === 'production') {
+      let request = fastboot.get('request');
+      request.protocol = 'https';
+      fastboot.set('request', request);
+    }
+
     return this.transitionTo('project', 'ember');
   }
 });

--- a/bin/ember-fastboot
+++ b/bin/ember-fastboot
@@ -21,9 +21,11 @@ if (!distPath) {
   process.exit(1);
 }
 
-let server = new FastBootAppServer({
+let serverConfig = {
   distPath: distPath,
-  gzip: true
-});
+  gzip: false // Let fastly take care of compression, reducing load on the fastboot
+};
+
+let server = new FastBootAppServer(serverConfig);
 
 server.start();


### PR DESCRIPTION
This resolves the issue where the initial redirect switches over to http independent of the request's protocol.