### PR TITLE
Fix manifest to exclude missing files

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -84,13 +84,9 @@ module.exports = function(environment) {
     appcacheFile: "/manifest.appcache",
     excludePaths: ['index.html'],
     includePaths: [
-      `assets/vendor.js`,
-      `assets/vendor.css`,
-      `assets/ember-api-docs.js`,
-      `assets/ember-api-docs.css`,
-      `assets/images/header.svg`,
-      `assets/images/ember-logo.svg`,
-      `favicon.ico`],
+      `assets/`,
+      `favicon.ico`
+    ],
     pathPrefix: prepend,
     //network: ['api/'],
     showCreateDate: true


### PR DESCRIPTION
Before:
<img width="1148" alt="screenshot 2017-03-25 15 08 02" src="https://cloud.githubusercontent.com/assets/604117/24321636/0c346bba-1177-11e7-8ee8-5c7c47368ba9.png">


After:
<img width="1125" alt="screenshot 2017-03-25 15 10 33" src="https://cloud.githubusercontent.com/assets/604117/24321637/10a26eae-1177-11e7-93af-ec31ad071229.png">


@toddjordan chrome was trying to load some of those missing files so switching to just mention that parent folder name solved this