### PR TITLE
Https upgrade & remove workers support temporarily 

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,16 +1,6 @@
 <!DOCTYPE html>
-<html manifest="{{rootURL}}manifest.appcache" lang="en">
+<html lang="en">
   <head>
-    <script type='text/javascript'>
-       window.addEventListener('load', function(e) {
-         window.applicationCache.addEventListener('updateready', function(e) {
-           if (window.applicationCache.status == window.applicationCache.UPDATEREADY) {
-             window.applicationCache.swapCache();
-             window.location.reload();
-           }
-         }, false);
-       }, false);
-    </script>
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import ENV from 'ember-api-docs/config/environment';
 
 
-const { inject: { service } } = Ember;
+const { inject: { service }, isPresent } = Ember;
 
 export default Ember.Route.extend({
 
@@ -14,9 +14,10 @@ export default Ember.Route.extend({
     // This app doesn't get its own custom domain since its part of emberjs.com site
     // under the `/api/` path. Since there's no custom domain or ssl keys to
     // setup, we're convincing the fastboot server into believing we're serving over ssl.
-    if (fastboot.get('isFastBoot') && ENV.environment === 'production') {
+    if (fastboot.get('isFastBoot') && ENV.environment === 'production' && isPresent(ENV.CDN_URL)) {
       let request = fastboot.get('request');
       request.protocol = 'https';
+      request.host = ENV.CDN_URL;
       fastboot.set('request', request);
     }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -76,6 +76,7 @@ module.exports = function(environment) {
   let prepend = '';
   if ('FASTLY_CDN_URL' in process.env) {
     prepend = `https://${process.env.FASTLY_CDN_URL}/`;
+    ENV.CDN_URL = process.env.FASTLY_CDN_URL;
   }
 
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -58,7 +58,7 @@ module.exports = function(environment) {
     "connect-src": "'self' https://s3.amazonaws.com",
     "script-src": "'self' unsafe-inline use.typekit.net 'sha256-36n/xkZHEzq3lo4O+0jXMYbl+dWu3C8orOFHtcAH6HU='",
     "font-src": "'self' data://* https://fonts.gstatic.com",
-    "img-src": "'self'",
+    "img-src": "'self' data:",
     "style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com"
   };
 
@@ -73,24 +73,8 @@ module.exports = function(environment) {
 
   }
 
-  let prepend = '';
   if ('FASTLY_CDN_URL' in process.env) {
-    prepend = `https://${process.env.FASTLY_CDN_URL}/`;
     ENV.CDN_URL = process.env.FASTLY_CDN_URL;
-  }
-
-
-  ENV.manifest = {
-    enabled: true,
-    appcacheFile: "/manifest.appcache",
-    excludePaths: ['index.html'],
-    includePaths: [
-      `assets/`,
-      `favicon.ico`
-    ],
-    pathPrefix: prepend,
-    //network: ['api/'],
-    showCreateDate: true
   }
 
   return ENV;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "broccoli-asset-rev": "^2.5.0",
-    "broccoli-manifest": "github:racido/broccoli-manifest#pathprefix",
     "ember-a11y-testing": "0.4.1",
     "ember-anchor": "~0.1.8",
     "ember-browserify": "~1.1.13",
@@ -75,9 +74,6 @@
     "ember-power-select": "1.6.1",
     "ember-resolver": "^3.0.0",
     "ember-route-action-helper": "^2.0.2",
-    "ember-service-worker": "^0.6.2",
-    "ember-service-worker-asset-cache": "^0.6.0",
-    "ember-service-worker-index": "^0.6.1",
     "ember-source": "~2.12.0",
     "ember-truth-helpers": "^1.3.0",
     "fastboot-app-server": "1.0.0-rc.5",


### PR DESCRIPTION
Removing workers & manifest generation so that we can iron out fastly integration & then introduce workers again.