### PR TITLE
Removing Fastboot additional url that seems to break things when proxied

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -3,7 +3,7 @@ import config from './config/environment';
 
 const Router = Ember.Router.extend({
   location: config.locationType,
-  rootURL: config.routerRootURL
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,6 @@ module.exports = function(environment) {
     modulePrefix: 'ember-api-docs',
     environment: environment,
     rootURL: '/',
-    routerRootURL: '/',
     locationType: 'auto',
     API_HOST: 'https://s3.amazonaws.com/sk-ed',
     IS_FASTBOOT: !!process.env.EMBER_CLI_FASTBOOT,
@@ -63,14 +62,6 @@ module.exports = function(environment) {
   };
 
   if (environment === 'production') {
-
-    /**
-     * Ideally we want this to be only for fast boot. But we have to wait for
-     * https://github.com/ember-fastboot/ember-cli-fastboot/issues/254 to be
-     * solved for that
-     */
-    ENV.routerRootURL = '/api-new/';
-
   }
   ENV.manifest = {
     enabled: true,


### PR DESCRIPTION
When working with our Fastboot setup proxied in production, it turns out we don't need this change for Fastboot.