### PR TITLE
Revert "Removing Fastboot additional url that seems to break things when proxied"

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -3,7 +3,7 @@ import config from './config/environment';
 
 const Router = Ember.Router.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.routerRootURL
 });
 
 Router.map(function() {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'ember-api-docs',
     environment: environment,
     rootURL: '/',
+    routerRootURL: '/',
     locationType: 'auto',
     API_HOST: 'https://s3.amazonaws.com/sk-ed',
     IS_FASTBOOT: !!process.env.EMBER_CLI_FASTBOOT,
@@ -62,6 +63,14 @@ module.exports = function(environment) {
   };
 
   if (environment === 'production') {
+
+    /**
+     * Ideally we want this to be only for fast boot. But we have to wait for
+     * https://github.com/ember-fastboot/ember-cli-fastboot/issues/254 to be
+     * solved for that
+     */
+    ENV.routerRootURL = '/api-new/';
+
   }
 
   if ('FASTLY_CDN_URL' in process.env) {


### PR DESCRIPTION
Reverts ember-learn/ember-api-docs#204. @acorncom I was too quick to merge this. we need the router's base url to be `/api-new` if not the links will point to `emberjs.com/ember/2.12/` instead of `emberjs.com/api-new/ember/2.12`. I think the problem with double `api-new` coming up again is because of what EMBER_API_DOCS_URL is set to on the website's instance.