### PR TITLE
call trackPage on transitions with requestIdleCallback

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,9 +1,20 @@
 import Ember from 'ember';
 import config from './config/environment';
 
+const { on } = Ember;
+
 const Router = Ember.Router.extend({
   location: config.locationType,
-  rootURL: config.routerRootURL
+  rootURL: config.routerRootURL,
+
+  sendPageViewToGA: on('didTransition', function(page, title) {
+    if (typeof FastBoot === 'undefined') {
+      page = page ? page : this.get('url');
+      title = title ? title : this.get('url');
+      const analyticsService = Ember.getOwner(this).lookup('service:analytics');
+      analyticsService.trackPage(page, title);
+    }
+  })
 });
 
 Router.map(function() {

--- a/app/services/analytics.js
+++ b/app/services/analytics.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import config from 'ember-api-docs/config/environment';
+import { requestIdlePromise } from 'ember-api-docs/utils/request-idle-callback';
+
+const { computed, $ } = Ember;
+
+export default Ember.Service.extend({
+
+  googleAnalytics: computed(function() {
+    return requestIdlePromise({timeout: 1000}).then(() => {
+      return $.getScript('https://www.google-analytics.com/analytics.js');
+    }).then(() => {
+      window.ga('create', config.gaTrackingId, 'auto');
+    });
+  }),
+
+  trackPage(page, title) {
+    return this.get('googleAnalytics').then(() => {
+      return requestIdlePromise({timeout: 1000});
+    }).then(() => {
+      window.ga('send', {
+        hitType: 'pageview',
+        page,
+        title
+      });
+    });
+  }
+});

--- a/app/utils/request-idle-callback.js
+++ b/app/utils/request-idle-callback.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+const { RSVP, run } = Ember;
+
+export function requestIdleCb(cb, opts) {
+  if ('requestIdleCallback' in window) {
+    return requestIdleCallback(cb, opts);
+  } else {
+    return run.shceduleOnce('afterRender', cb);
+  }
+}
+
+export function requestIdlePromise({timeout}) {
+  return new RSVP.Promise(resolve => {
+    requestIdleCb(resolve, {timeout});
+  });
+}

--- a/app/utils/request-idle-callback.js
+++ b/app/utils/request-idle-callback.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 
 const { RSVP, run } = Ember;
 
-export function requestIdleCb(cb, opts) {
+function requestIdleCb(cb, opts) {
   if ('requestIdleCallback' in window) {
     return requestIdleCallback(cb, opts);
   } else {
-    return run.shceduleOnce('afterRender', cb);
+    return run.scheduleOnce('afterRender', cb);
   }
 }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -9,6 +9,7 @@ module.exports = function(environment) {
     locationType: 'auto',
     API_HOST: 'https://s3.amazonaws.com/sk-ed',
     IS_FASTBOOT: !!process.env.EMBER_CLI_FASTBOOT,
+    gaTrackingId: 'UA-XXXXX-Y',
     EmberENV: {
       EXTEND_PROTOTYPES: false,
       FEATURES: {
@@ -56,9 +57,9 @@ module.exports = function(environment) {
   ENV.contentSecurityPolicy = {
     "default-src": "'self' *.fastly.net",
     "connect-src": "'self' https://s3.amazonaws.com  *.fastly.net",
-    "script-src": "'self' unsafe-inline use.typekit.net 'sha256-36n/xkZHEzq3lo4O+0jXMYbl+dWu3C8orOFHtcAH6HU=' *.fastly.net",
+    "script-src": "'self' unsafe-inline use.typekit.net 'sha256-36n/xkZHEzq3lo4O+0jXMYbl+dWu3C8orOFHtcAH6HU=' *.fastly.net https://www.google-analytics.com",
     "font-src": "'self' data://* https://fonts.gstatic.com  *.fastly.net",
-    "img-src": "'self' data://*  *.fastly.net",
+    "img-src": "'self' data://*  *.fastly.net https://www.google-analytics.com",
     "style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com  *.fastly.net"
   };
 
@@ -70,6 +71,7 @@ module.exports = function(environment) {
      * solved for that
      */
     ENV.routerRootURL = '/api-new/';
+    ENV.gaTrackingId = 'UA-27675533-1';
 
   }
 

--- a/tests/acceptance/analytics-page-tracking-test.js
+++ b/tests/acceptance/analytics-page-tracking-test.js
@@ -1,0 +1,37 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
+import Ember from 'ember';
+import { requestIdlePromise } from 'ember-api-docs/utils/request-idle-callback';
+
+moduleForAcceptance('Acceptance | analytics page tracking');
+
+test('checking that trackPage gets called on transitions', function(assert) {
+
+  const pages = ['/ember/2.11.3/namespaces/Ember', '/ember/2.11.3/modules/ember-metal', '/ember/2.11.3/classes/Ember.Application'];
+  const pagesClone = pages.slice(0);
+  const analyticsService = this.application.__container__.lookup('service:analytics');
+  assert.expect(pages.length);
+
+  // extend the method to add assertion in it
+  let oldTrackPage = analyticsService.trackPage;
+  analyticsService.trackPage = (page, title) => {
+    Ember.run(() => {
+      oldTrackPage.apply(analyticsService, ...arguments).then(() => assert.equal(page, pagesClone.shift()));
+    });
+  };
+
+  visit(pages[0]);
+
+  andThen(function() {
+    visit(pages[1]);
+  });
+
+  andThen(function() {
+    visit(pages[2]);
+  });
+
+  andThen(function() {
+    // make sure the test runner waits for last idle callback
+    return requestIdlePromise(2000);
+  });
+});


### PR DESCRIPTION
fixes #183

I know it's not MVP but I did it recently in a different app so it was a quick fix for me. It is wrapped in requestIdleCallback so the analytics should not delay time to interactivity.

The acceptance test failed randomly once for me, probably because of concurrency, so I added some extra guards (the `run` call and last `andThen`) and It seems to be fixed. I re-run it like 20 times and it did not fail again.