### PR TITLE
don't need these steps since the ember buildpack does it for us

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember exam",
-    "postinstall": "npm rebuild node-sass",
-    "heroku-prebuild": "npm i -g bower",
-    "heroku-postbuild": "bower install && rm -rf tmp/deploy-dist && ember deploy production && cd tmp/deploy-dist && npm install --production && cd ../.."
+    "postinstall": "npm rebuild node-sass"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For both CI and deployment, the buildpack handles installing `bower` and doing fastboot stuff. Let's try removing this stuff from `package.json`.