### PR TITLE
Use "ember-native-dom-helpers" for acceptance and integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-lodash": "^4.17.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-native-dom-helpers": "^0.4.1",
     "ember-network": "^0.3.1",
     "ember-power-select": "^1.6.1",
     "ember-resolver": "^4.1.0",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  env: {
-    'embertest': true
-  },
   globals: {
+    'currentURL': true,
     'selectSearch': true,
     'selectChoose': true
   }

--- a/tests/acceptance/analytics-page-tracking-test.js
+++ b/tests/acceptance/analytics-page-tracking-test.js
@@ -1,4 +1,5 @@
 import { test } from 'qunit';
+import { visit } from 'ember-native-dom-helpers';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import Ember from 'ember';
 import { requestIdlePromise } from 'ember-api-docs/utils/request-idle-callback';

--- a/tests/acceptance/app-layout-test.js
+++ b/tests/acceptance/app-layout-test.js
@@ -1,5 +1,6 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import {test} from 'qunit';
+import { visit } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | Application Layout');
 

--- a/tests/acceptance/class-test.js
+++ b/tests/acceptance/class-test.js
@@ -1,38 +1,39 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import {test} from 'qunit';
 import $ from 'jquery';
+import { visit, click, findAll } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | Class', {
   async beforeEach() {
     await visit('/ember/1.0.0/classes/Container');
-    await click('.access-checkbox:contains(Inherited)');
-    await click('.access-checkbox:contains(Protected)');
-    await click('.access-checkbox:contains(Private)');
-    await click('.access-checkbox:contains(Deprecated)');
+    await click($('.access-checkbox:contains(Inherited)')[0]);
+    await click($('.access-checkbox:contains(Protected)')[0]);
+    await click($('.access-checkbox:contains(Private)')[0]);
+    await click($('.access-checkbox:contains(Deprecated)')[0]);
   }
 });
 
 test('lists all the methods on the class page', async function (assert) {
   const store = this.application.__container__.lookup('service:store');
   const container = store.peekRecord('class', 'ember-1.0.0-Container');
-  assert.equal($(findWithAssert('.spec-method-list li')).length, container.get('methods.length'));
+  assert.equal(findAll('.spec-method-list li').length, container.get('methods.length'));
 
-  await click('.access-checkbox:contains(Private)'); // turn private back off
+  await click($('.access-checkbox:contains(Private)')[0]); // turn private back off
 
-  assert.equal($(findWithAssert('.spec-method-list li')).length,
+  assert.equal(findAll('.spec-method-list li').length,
     container.get('methods').filter(method => method.access !== 'private').length);
 });
 
 test('lists all the properties on the class page', function (assert) {
   const store = this.application.__container__.lookup('service:store');
   const container = store.peekRecord('class', 'ember-1.0.0-Container');
-  assert.equal($(findWithAssert('.spec-property-list li')).length, container.get('properties.length'));
+  assert.equal(findAll('.spec-property-list li').length, container.get('properties.length'));
 });
 
 test('lists all the events on the class page', function (assert) {
   const store = this.application.__container__.lookup('service:store');
   const container = store.peekRecord('class', 'ember-1.0.0-Container');
-  assert.equal($(find('.spec-event-list li')).length, container.get('events.length'));
+  assert.equal(findAll('.spec-event-list li').length, container.get('events.length'));
 });
 
 test('has query params for access visibilities', function (assert) {

--- a/tests/acceptance/items-test.js
+++ b/tests/acceptance/items-test.js
@@ -1,39 +1,41 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import {test} from 'qunit';
+import { visit, click } from 'ember-native-dom-helpers';
+import $ from 'jquery';
 
 moduleForAcceptance('Acceptance | ItemRoutes');
 
 test('Can navigate to method from class', async function(assert) {
   await visit('/ember/1.0.0/classes/Container');
-  await click('.spec-method-list a:contains(child)');
+  await click($('.spec-method-list a:contains(child)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/classes/Container/methods/child?anchor=child', 'navigated to method');
 });
 
 test('Can navigate to property from class', async function(assert) {
   await visit('/ember/1.0.0/classes/Container');
-  await click('.spec-property-list a:contains(cache)');
+  await click($('.spec-property-list a:contains(cache)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/classes/Container/properties/cache?anchor=cache', 'navigated to property');
 });
 
 test('Can navigate to method from namespace', async function(assert) {
   await visit('/ember/1.0.0/namespaces/Ember');
-  await click('.spec-method-list a:contains(A)');
+  await click($('.spec-method-list a:contains(A)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/namespaces/Ember/methods/A?anchor=A', 'navigated to method');
 });
 
 test('Can navigate to property from namespace', async function(assert) {
   await visit('/ember/1.0.0/namespaces/Ember');
-  await click('.spec-property-list a:contains(ENV)');
+  await click($('.spec-property-list a:contains(ENV)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/namespaces/Ember/properties/ENV?anchor=ENV', 'navigated to property');
 });
 
 test('Can navigate to event from namespace', async function(assert) {
   await visit('/ember/1.0.0/namespaces/Ember');
-  await click('.spec-event-list a:contains(onerror)');
+  await click($('.spec-event-list a:contains(onerror)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/namespaces/Ember/events/onerror?anchor=onerror', 'navigated to event');
 });

--- a/tests/acceptance/module-test.js
+++ b/tests/acceptance/module-test.js
@@ -1,5 +1,6 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import { test } from 'qunit';
+import { visit, click } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | Module');
 

--- a/tests/acceptance/open-graph-tags-test.js
+++ b/tests/acceptance/open-graph-tags-test.js
@@ -1,5 +1,6 @@
 import { test } from 'qunit';
 import $ from 'jquery';
+import { visit } from 'ember-native-dom-helpers';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 

--- a/tests/acceptance/redirects-test.js
+++ b/tests/acceptance/redirects-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import _ from 'lodash';
+import { visit } from 'ember-native-dom-helpers';
 import semverCompare from 'npm:semver-compare';
 
 moduleForAcceptance('Acceptance | redirects');

--- a/tests/acceptance/scroll-reset-on-transition-test.js
+++ b/tests/acceptance/scroll-reset-on-transition-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import Ember from 'ember';
+import { visit } from 'ember-native-dom-helpers';
 
 const { $ } = Ember;
 

--- a/tests/acceptance/sidebar-nav-test.js
+++ b/tests/acceptance/sidebar-nav-test.js
@@ -1,4 +1,6 @@
 import { test } from 'qunit';
+import { visit, click } from 'ember-native-dom-helpers';
+import $ from 'jquery';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
@@ -6,21 +8,21 @@ moduleForAcceptance('Acceptance | sidebar navigation');
 
 test('can navigate to namespace from sidebar', async function(assert) {
   await visit('/ember/1.0.0');
-  await click('.toc-level-1.namespaces a:contains(Ember.String)');
+  await click($('.toc-level-1.namespaces a:contains(Ember.String)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/namespaces/Ember.String', 'navigated to namespace');
 });
 
 test('can navigate to module from sidebar', async function(assert) {
   await visit('/ember/1.0.0');
-  await click('.toc-level-1.modules a:contains(ember-application)');
+  await click($('.toc-level-1.modules a:contains(ember-application)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/modules/ember-application', 'navigated to module');
 });
 
 test('can navigate to class from sidebar', async function(assert) {
   await visit('/ember/1.0.0');
-  await click('.toc-level-1.classes a:contains(Ember.Component)');
+  await click($('.toc-level-1.classes a:contains(Ember.Component)')[0]);
 
   assert.equal(currentURL(), '/ember/1.0.0/classes/Ember.Component', 'navigated to class');
 });

--- a/tests/acceptance/switch-project-test.js
+++ b/tests/acceptance/switch-project-test.js
@@ -1,5 +1,7 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import {test} from 'qunit';
+import { visit, click, findAll, findWithAssert } from 'ember-native-dom-helpers';
+import $ from 'jquery';
 
 moduleForAcceptance('Acceptance | Switch Project');
 
@@ -7,21 +9,21 @@ test('Can switch projects back and forth', async function(assert) {
   async function ensureVersionsExist() {
     await selectSearch('.select-container', '2');
 
-    assert.equal(find('.ember-power-select-options').length, 1);
-    assert.ok(find('.ember-power-select-options')[0].children.length > 1);
+    assert.equal(findAll('.ember-power-select-options').length, 1);
+    assert.ok(findAll('.ember-power-select-options')[0].children.length > 1);
   }
 
   await visit('/');
 
   await click('.spec-ember-data');
   await ensureVersionsExist();
-  assert.ok(findWithAssert('.spec-ember-data').hasClass('active'));
+  assert.ok($(findWithAssert('.spec-ember-data')).hasClass('active'));
 
   await click('.spec-ember');
   await ensureVersionsExist();
-  assert.ok(findWithAssert('.spec-ember').hasClass('active'));
+  assert.ok($(findWithAssert('.spec-ember')).hasClass('active'));
 
   await click('.spec-ember-data');
   await ensureVersionsExist();
-  assert.ok(findWithAssert('.spec-ember-data').hasClass('active'));
+  assert.ok($(findWithAssert('.spec-ember-data')).hasClass('active'));
 });

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -1,4 +1,5 @@
 import { test } from 'qunit';
+import { visit } from 'ember-native-dom-helpers';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 

--- a/tests/acceptance/tab-nav-test.js
+++ b/tests/acceptance/tab-nav-test.js
@@ -1,4 +1,6 @@
 import { test } from 'qunit';
+import { visit, click } from 'ember-native-dom-helpers';
+import $ from 'jquery';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
@@ -10,24 +12,24 @@ moduleForAcceptance('Acceptance | tab navigation');
 
 test('switching tabs', async function(assert) {
   await visit('/ember/1.0.0/classes/Ember.Component');
-  await click('.access-checkbox:contains(Inherited)');
-  await click('.tabbed-layout__menu li:contains(Methods)');
+  await click($('.access-checkbox:contains(Inherited)')[0]);
+  await click($('.tabbed-layout__menu li:contains(Methods)')[0]);
 
   assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component/methods', 'navigated to methods');
-  assert.ok(find('.tabbed-layout__menu li:contains(Methods)').hasClass('tabbed-layout__menu__item_selected'), 'methods tab selected');
+  assert.ok($('.tabbed-layout__menu li:contains(Methods)').hasClass('tabbed-layout__menu__item_selected'), 'methods tab selected');
 
-  await click('.tabbed-layout__menu li:contains(Properties)');
+  await click($('.tabbed-layout__menu li:contains(Properties)')[0]);
 
   assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component/properties', 'navigated to properties');
-  assert.ok(find('.tabbed-layout__menu li:contains(Properties)').hasClass('tabbed-layout__menu__item_selected'), 'properties tab selected');
+  assert.ok($('.tabbed-layout__menu li:contains(Properties)').hasClass('tabbed-layout__menu__item_selected'), 'properties tab selected');
 
-  await click('.tabbed-layout__menu li:contains(Events)');
+  await click($('.tabbed-layout__menu li:contains(Events)')[0]);
 
   assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component/events', 'navigated to events');
-  assert.ok(find('.tabbed-layout__menu li:contains(Events)').hasClass('tabbed-layout__menu__item_selected'), 'events tab selected');
+  assert.ok($('.tabbed-layout__menu li:contains(Events)').hasClass('tabbed-layout__menu__item_selected'), 'events tab selected');
 
-  await click('.tabbed-layout__menu li:contains(Index)');
+  await click($('.tabbed-layout__menu li:contains(Index)')[0]);
 
   assert.equal(currentURLNoParams(), '/ember/1.0.0/classes/Ember.Component', 'navigated to index');
-  assert.ok(find('.tabbed-layout__menu li:contains(Index)').hasClass('tabbed-layout__menu__item_selected'), 'index tab selected');
+  assert.ok($('.tabbed-layout__menu li:contains(Index)').hasClass('tabbed-layout__menu__item_selected'), 'index tab selected');
 });

--- a/tests/acceptance/title-test.js
+++ b/tests/acceptance/title-test.js
@@ -1,4 +1,5 @@
 import { test } from 'qunit';
+import { visit } from 'ember-native-dom-helpers';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 

--- a/tests/integration/components/api-index-filter-test.js
+++ b/tests/integration/components/api-index-filter-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
+import { click, findAll } from 'ember-native-dom-helpers';
 
 moduleForComponent('api-index-filter', 'Integration | Component | api index filter', {
   integration: true
@@ -55,7 +56,7 @@ const model = Ember.Object.create({
 });
 
 
-test('clicking inherited shows inherited methods', function(assert) {
+test('clicking inherited shows inherited methods', async function(assert) {
   let filterData = Ember.Object.create({
     showInherited: false,
     showProtected: false,
@@ -108,13 +109,13 @@ test('clicking inherited shows inherited methods', function(assert) {
     {{/api-index-filter}}
   `);
 
-  this.$('#inherited-toggle').click();
-  assert.equal(this.$('.method-name:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.method-name:eq(1)').text().trim(), 'parentDoSomething', 'should display 1 inherited method');
-  assert.equal(this.$('.method-name').length, 2, 'should display 2 methods total');
+  await click('#inherited-toggle');
+  assert.equal(findAll('.method-name').length, 2, 'should display 2 methods total');
+  assert.equal(findAll('.method-name')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
+  assert.equal(findAll('.method-name')[1].textContent.trim(), 'parentDoSomething', 'should display 1 inherited method');
 });
 
-test('clicking private shows private methods', function(assert) {
+test('clicking private shows private methods', async function(assert) {
   let filterData = Ember.Object.create({
     showInherited: false,
     showProtected: false,
@@ -167,13 +168,13 @@ test('clicking private shows private methods', function(assert) {
     {{/api-index-filter}}
   `);
 
-  this.$('#private-toggle').click();
-  assert.equal(this.$('.method-name:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.method-name:eq(1)').text().trim(), 'doSomethingPrivate', 'should display 1 private method');
-  assert.equal(this.$('.method-name').length, 2, 'should display 2 methods total');
+  await click('#private-toggle');
+  assert.equal(findAll('.method-name').length, 2, 'should display 2 methods total');
+  assert.equal(findAll('.method-name')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
+  assert.equal(findAll('.method-name')[1].textContent.trim(), 'doSomethingPrivate', 'should display 1 private method');
 });
 
-test('clicking private and inherited shows both methods', function(assert) {
+test('clicking private and inherited shows both methods', async function(assert) {
   let filterData = Ember.Object.create({
     showInherited: false,
     showProtected: false,
@@ -226,16 +227,16 @@ test('clicking private and inherited shows both methods', function(assert) {
     {{/api-index-filter}}
   `);
 
-  this.$('#private-toggle').click();
-  this.$('#inherited-toggle').click();
-  assert.equal(this.$('.method-name:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.method-name:eq(1)').text().trim(), 'doSomethingPrivate', 'should display 1 private method');
-  assert.equal(this.$('.method-name:eq(2)').text().trim(), 'parentDoSomething', 'should display 1 inherited method');
-  assert.equal(this.$('.method-name').length, 3, 'should display 3 methods total');
+  await click('#private-toggle');
+  await click('#inherited-toggle');
+  assert.equal(findAll('.method-name').length, 3, 'should display 3 methods total');
+  assert.equal(findAll('.method-name')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
+  assert.equal(findAll('.method-name')[1].textContent.trim(), 'doSomethingPrivate', 'should display 1 private method');
+  assert.equal(findAll('.method-name')[2].textContent.trim(), 'parentDoSomething', 'should display 1 inherited method');
 });
 
 
-test('clicking all toggles shows all methods', function(assert) {
+test('clicking all toggles shows all methods', async function(assert) {
   let filterData = Ember.Object.create({
     showInherited: false,
     showProtected: false,
@@ -288,20 +289,20 @@ test('clicking all toggles shows all methods', function(assert) {
     {{/api-index-filter}}
   `);
 
-  this.$('#private-toggle').click();
-  this.$('#inherited-toggle').click();
-  this.$('#protected-toggle').click();
-  this.$('#deprecated-toggle').click();
-  assert.equal(this.$('.method-name:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.method-name:eq(1)').text().trim(), 'doSomethingDeprecated', 'should display 1 deprecated method');
-  assert.equal(this.$('.method-name:eq(2)').text().trim(), 'doSomethingPrivate', 'should display 1 private method');
-  assert.equal(this.$('.method-name:eq(3)').text().trim(), 'doSomethingProtected', 'should display 1 protected method');
-  assert.equal(this.$('.method-name:eq(4)').text().trim(), 'parentDoSomething', 'should display 1 inherited method');
-  assert.equal(this.$('.method-name').length, 5, 'should display all methods');
+  await click('#private-toggle');
+  await click('#inherited-toggle');
+  await click('#protected-toggle');
+  await click('#deprecated-toggle');
+  assert.equal(findAll('.method-name').length, 5, 'should display all methods');
+  assert.equal(findAll('.method-name')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
+  assert.equal(findAll('.method-name')[1].textContent.trim(), 'doSomethingDeprecated', 'should display 1 deprecated method');
+  assert.equal(findAll('.method-name')[2].textContent.trim(), 'doSomethingPrivate', 'should display 1 private method');
+  assert.equal(findAll('.method-name')[3].textContent.trim(), 'doSomethingProtected', 'should display 1 protected method');
+  assert.equal(findAll('.method-name')[4].textContent.trim(), 'parentDoSomething', 'should display 1 inherited method');
 });
 
 
-test('clicking all toggles off should only show public', function(assert) {
+test('clicking all toggles off should only show public', async function(assert) {
   let filterData = Ember.Object.create({
     showInherited: true,
     showProtected: true,
@@ -354,19 +355,19 @@ test('clicking all toggles off should only show public', function(assert) {
     {{/api-index-filter}}
   `);
 
-  assert.equal(this.$('.method-name:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.method-name:eq(1)').text().trim(), 'doSomethingDeprecated', 'should display 1 deprecated method');
-  assert.equal(this.$('.method-name:eq(2)').text().trim(), 'doSomethingPrivate', 'should display 1 private method');
-  assert.equal(this.$('.method-name:eq(3)').text().trim(), 'doSomethingProtected', 'should display 1 protected method');
-  assert.equal(this.$('.method-name:eq(4)').text().trim(), 'parentDoSomething', 'should display 1 inherited method');
-  assert.equal(this.$('.method-name').length, 5, 'should display all methods');
+  assert.equal(findAll('.method-name').length, 5, 'should display all methods');
+  assert.equal(findAll('.method-name')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
+  assert.equal(findAll('.method-name')[1].textContent.trim(), 'doSomethingDeprecated', 'should display 1 deprecated method');
+  assert.equal(findAll('.method-name')[2].textContent.trim(), 'doSomethingPrivate', 'should display 1 private method');
+  assert.equal(findAll('.method-name')[3].textContent.trim(), 'doSomethingProtected', 'should display 1 protected method');
+  assert.equal(findAll('.method-name')[4].textContent.trim(), 'parentDoSomething', 'should display 1 inherited method');
 
-  this.$('#private-toggle').click();
-  this.$('#inherited-toggle').click();
-  this.$('#protected-toggle').click();
-  this.$('#deprecated-toggle').click();
+  await click('#private-toggle');
+  await click('#inherited-toggle');
+  await click('#protected-toggle');
+  await click('#deprecated-toggle');
 
-  assert.equal(this.$('.method-name:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.method-name').length, 1, 'should display all methods');
+  assert.equal(findAll('.method-name').length, 1, 'should display all methods');
+  assert.equal(findAll('.method-name')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
 
 });

--- a/tests/integration/components/api-index-test.js
+++ b/tests/integration/components/api-index-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import { click, findAll, find } from 'ember-native-dom-helpers';
 
 moduleForComponent('api-index', 'Integration | Component | api index', {
   integration: true
@@ -62,13 +63,13 @@ test('should display api index', function (assert) {
         {{/each}}
       {{/api-index}}
   `);
-  assert.equal(this.$('.api-index-section-title').length, 3, 'should show 3 sections');
-  assert.equal(this.$('.api-index-section-title:eq(0)').text(), 'Methods', 'should have methods as first section');
-  assert.equal(this.$('.api-index-section-title:eq(1)').text(), 'Properties', 'should have properties as second section');
-  assert.equal(this.$('.api-index-section-title:eq(2)').text(), 'Events', 'should have events as third section');
-  assert.equal(this.$('.spec-method-list>li>a').text().trim(), 'doSomething', 'should display 1 method');
-  assert.equal(this.$('.spec-property-list>li>a').text().trim(), 'isSomething', 'should display 1 property');
-  assert.equal(this.$('.spec-event-list>li>a').text().trim(), 'didSomething', 'should display 1 event');
+  assert.equal(findAll('.api-index-section-title').length, 3, 'should show 3 sections');
+  assert.equal(findAll('.api-index-section-title')[0].textContent, 'Methods', 'should have methods as first section');
+  assert.equal(findAll('.api-index-section-title')[1].textContent, 'Properties', 'should have properties as second section');
+  assert.equal(findAll('.api-index-section-title')[2].textContent, 'Events', 'should have events as third section');
+  assert.equal(find('.spec-method-list>li>a').textContent.trim(), 'doSomething', 'should display 1 method');
+  assert.equal(find('.spec-property-list>li>a').textContent.trim(), 'isSomething', 'should display 1 property');
+  assert.equal(find('.spec-event-list>li>a').textContent.trim(), 'didSomething', 'should display 1 event');
 });
 
 test('should display text when no methods', function (assert) {
@@ -122,13 +123,13 @@ test('should display text when no methods', function (assert) {
         {{/each}}
       {{/api-index}}
   `);
-  assert.equal(this.$('.api-index-section-title').length, 3, 'should show 3 sections');
-  assert.equal(this.$('.api-index-section-title:eq(0)').text(), 'Methods', 'should have methods as first section');
-  assert.equal(this.$('.api-index-section-title:eq(1)').text(), 'Properties', 'should have properties as second section');
-  assert.equal(this.$('.api-index-section-title:eq(2)').text(), 'Events', 'should have events as third section');
-  assert.equal(this.$('.spec-method-list').text().trim(), 'No documented items', 'should display no items text');
-  assert.equal(this.$('.spec-property-list').text().trim(), 'isSomething', 'should display 1 property');
-  assert.equal(this.$('.spec-event-list').text().trim(), 'didSomething', 'should display 1 event');
+  assert.equal(findAll('.api-index-section-title').length, 3, 'should show 3 sections');
+  assert.equal(findAll('.api-index-section-title')[0].textContent, 'Methods', 'should have methods as first section');
+  assert.equal(findAll('.api-index-section-title')[1].textContent, 'Properties', 'should have properties as second section');
+  assert.equal(findAll('.api-index-section-title')[2].textContent, 'Events', 'should have events as third section');
+  assert.equal(find('.spec-method-list').textContent.trim(), 'No documented items', 'should display no items text');
+  assert.equal(find('.spec-property-list').textContent.trim(), 'isSomething', 'should display 1 property');
+  assert.equal(find('.spec-event-list').textContent.trim(), 'didSomething', 'should display 1 event');
 });
 
 test('should display api index with filter', function (assert) {
@@ -252,17 +253,17 @@ test('should display api index with filter', function (assert) {
       {{/api-index}}
     {{/api-index-filter}}
   `);
-  assert.equal(this.$('.api-index-section-title').length, 3, 'should show 3 sections');
-  assert.equal(this.$('.api-index-section-title:eq(0)').text(), 'Methods', 'should have methods as first section');
-  assert.equal(this.$('.api-index-section-title:eq(1)').text(), 'Properties', 'should have properties as second section');
-  assert.equal(this.$('.api-index-section-title:eq(2)').text(), 'Events', 'should have events as third section');
-  assert.equal(this.$('.spec-method-list').text().trim(), 'doSomething', 'should display 1 method');
-  assert.equal(this.$('.spec-property-list').text().trim(), 'isSomething', 'should display 1 property');
-  assert.equal(this.$('.spec-event-list').text().trim(), 'didSomething', 'should display 1 event');
+  assert.equal(findAll('.api-index-section-title').length, 3, 'should show 3 sections');
+  assert.equal(findAll('.api-index-section-title')[0].textContent, 'Methods', 'should have methods as first section');
+  assert.equal(findAll('.api-index-section-title')[1].textContent, 'Properties', 'should have properties as second section');
+  assert.equal(findAll('.api-index-section-title')[2].textContent, 'Events', 'should have events as third section');
+  assert.equal(find('.spec-method-list').textContent.trim(), 'doSomething', 'should display 1 method');
+  assert.equal(find('.spec-property-list').textContent.trim(), 'isSomething', 'should display 1 property');
+  assert.equal(find('.spec-event-list').textContent.trim(), 'didSomething', 'should display 1 event');
 });
 
 
-test('should display inherited method when show inherited toggled on', function (assert) {
+test('should display inherited method when show inherited toggled on', async function(assert) {
   let model = Ember.Object.create({
     project: {
       id: 'lolwut'
@@ -381,17 +382,17 @@ test('should display inherited method when show inherited toggled on', function 
       {{/api-index}}
     {{/api-index-filter}}
   `);
-  assert.equal(this.$('.api-index-section-title').length, 3, 'should show 3 sections');
-  assert.equal(this.$('.api-index-section-title:eq(0)').text(), 'Methods', 'should have methods as first section');
-  assert.equal(this.$('.api-index-section-title:eq(1)').text(), 'Properties', 'should have properties as second section');
-  assert.equal(this.$('.api-index-section-title:eq(2)').text(), 'Events', 'should have events as third section');
-  assert.equal(this.$('.spec-method-list>li>a').text().trim(), 'doSomething', 'should display 1 method');
-  assert.equal(this.$('.spec-property-list>li>a').text().trim(), 'isSomething', 'should display 1 property');
-  assert.equal(this.$('.spec-event-list>li>a').text().trim(), 'didSomething', 'should display 1 event');
+  assert.equal(findAll('.api-index-section-title').length, 3, 'should show 3 sections');
+  assert.equal(findAll('.api-index-section-title')[0].textContent, 'Methods', 'should have methods as first section');
+  assert.equal(findAll('.api-index-section-title')[1].textContent, 'Properties', 'should have properties as second section');
+  assert.equal(findAll('.api-index-section-title')[2].textContent, 'Events', 'should have events as third section');
+  assert.equal(find('.spec-method-list>li>a').textContent.trim(), 'doSomething', 'should display 1 method');
+  assert.equal(find('.spec-property-list>li>a').textContent.trim(), 'isSomething', 'should display 1 property');
+  assert.equal(find('.spec-event-list>li>a').textContent.trim(), 'didSomething', 'should display 1 event');
 
-  this.$('#inherited-toggle').click();
+  await click('#inherited-toggle');
 
-  assert.equal(this.$('.spec-method-list>li>a:eq(0)').text().trim(), 'doSomething', 'should display 1 public method');
-  assert.equal(this.$('.spec-method-list>li>a:eq(1)').text().trim(), 'parentDoSomething', 'should display 1 inherited method');
-  assert.equal(this.$('.spec-method-list>li>a').length, 2, 'should display 2 methods total');
+  assert.equal(findAll('.spec-method-list>li>a').length, 2, 'should display 2 methods total');
+  assert.equal(findAll('.spec-method-list>li>a')[0].textContent.trim(), 'doSomething', 'should display 1 public method');
+  assert.equal(findAll('.spec-method-list>li>a')[1].textContent.trim(), 'parentDoSomething', 'should display 1 inherited method');
 });

--- a/tests/integration/components/class-field-description-test.js
+++ b/tests/integration/components/class-field-description-test.js
@@ -1,6 +1,7 @@
 import Ember from "ember";
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { find, findAll } from 'ember-native-dom-helpers';
 
 moduleForComponent('class-field-description', 'Integration | Component | class field description', {
   integration: true
@@ -18,8 +19,8 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{class-field-description type=type field=field}}`);
 
-  assert.equal(this.$().find('.method-name').text().trim(), 'concat');
-  assert.equal(this.$().find('.access').eq(0).text().trim(), 'public');
-  assert.equal(this.$().find('.access').eq(1).text().trim(), 'deprecated');
-  assert.equal(this.$().find('.args').eq(0).text().trim(), '(param1, param2, param3)');
+  assert.equal(find('.method-name').textContent.trim(), 'concat');
+  assert.equal(findAll('.access')[0].textContent.trim(), 'public');
+  assert.equal(findAll('.access')[1].textContent.trim(), 'deprecated');
+  assert.equal(findAll('.args')[0].textContent.trim(), '(param1, param2, param3)');
 });

--- a/tests/integration/components/table-of-contents-test.js
+++ b/tests/integration/components/table-of-contents-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { findAll } from 'ember-native-dom-helpers';
 
 moduleForComponent('table-of-contents', 'Integration | Component | table of contents', {
   integration: true
@@ -21,8 +22,8 @@ test('it renders', function(assert) {
                                       classesIDs=classesIDs
                   }}`);
 
-  assert.equal(this.$('.toc-level-0 > a').last().text().trim(), 'Classes');
-  assert.equal(this.$('.toc-level-1 li').length, 2, 'We have two items to display');
-  assert.equal(this.$('.toc-level-1 li').eq(0).text(), 'Descriptor');
-  assert.equal(this.$('.toc-level-1 li').eq(1).text(), 'Ember');
+  assert.equal(findAll('.toc-level-0 > a')[2].textContent.trim(), 'Classes');
+  assert.equal(findAll('.toc-level-1 li').length, 2, 'We have two items to display');
+  assert.equal(findAll('.toc-level-1 li')[0].textContent, 'Descriptor');
+  assert.equal(findAll('.toc-level-1 li')[1].textContent, 'Ember');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,7 +3348,7 @@ ember-maybe-import-regenerator@^0.1.5, ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-native-dom-helpers@^0.4.0:
+ember-native-dom-helpers@^0.4.0, ember-native-dom-helpers@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.4.1.tgz#c4db7afa25dbe3efd84f36376f1ede2678cd7bb0"
   dependencies:


### PR DESCRIPTION
see https://github.com/cibernox/ember-native-dom-helpers

Disclaimer: This is still not perfect and using jQuery in some cases. Eventually we should use e.g. `ember-test-selectors` to get rid of those jQuery selectors.

/cc @sivakumar-kailasam @mschinis @toddjordan @cibernox 