### PR TITLE
remove changing tagName of link-to and fix inverse relationships

### DIFF
--- a/app/models/module.js
+++ b/app/models/module.js
@@ -1,12 +1,14 @@
 import ClassModel from './class';
 import DS from 'ember-data';
 
-const { attr } = DS;
+const { attr, belongsTo } = DS;
 
 export default ClassModel.extend({
   submodules: attr(),
   publicclasses: attr(),
   privateclasses: attr(),
   namespaces: attr(),
-  parent: attr()
+  parent: attr(),
+
+  projectVersion: belongsTo('project-version', {inverse: 'modules'})
 });

--- a/app/models/namespace.js
+++ b/app/models/namespace.js
@@ -1,3 +1,8 @@
 import ClassModel from './class';
+import DS from 'ember-data';
 
-export default ClassModel.extend();
+const { belongsTo } = DS;
+
+export default ClassModel.extend({
+  projectVersion: belongsTo('project-version', {inverse: 'namespaces'})
+});

--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -42,13 +42,12 @@
 
   {{#if (or model.methods model.properties model.events)}}
     <div class="tabbed-layout">
-      <ul class="tabbed-layout__menu">
+      <nav class="tabbed-layout__menu">
         {{#link-to (concat parentName ".index")
            model.project.id
            model.projectVersion.version
            model.name
            (query-params anchor="")
-           tagName="li"
            class="tabbed-layout__menu__item"
            activeClass="tabbed-layout__menu__item_selected"
            current-when=(concat parentName ".index")
@@ -62,7 +61,6 @@
              model.projectVersion.version
              model.name
              (query-params anchor="")
-             tagName="li"
              class="tabbed-layout__menu__item"
              activeClass="tabbed-layout__menu__item_selected"
              current-when=(concat parentName ".methods")
@@ -77,7 +75,6 @@
              model.projectVersion.version
              model.name
              (query-params anchor="")
-             tagName="li"
              class="tabbed-layout__menu__item"
              activeClass="tabbed-layout__menu__item_selected"
              current-when=(concat parentName ".properties")
@@ -92,7 +89,6 @@
              model.projectVersion.version
              model.name
              (query-params anchor="")
-             tagName="li"
              class="tabbed-layout__menu__item"
              activeClass="tabbed-layout__menu__item_selected"
              current-when=(concat parentName ".events")
@@ -101,7 +97,7 @@
             <span>Events</span>
           {{/link-to}}
         {{/if}}
-      </ul>
+      </nav>
       <section>
         Show:
         <label class="access-checkbox">


### PR DESCRIPTION
This should fix #213.

The issue there was, that after some time `projectVersion` on the namespace model became undefined.

Maybe because of wrong `inverse` key.

![screen shot 2017-07-02 at 13 12 05](https://user-images.githubusercontent.com/9468793/27769489-a484759e-5f2a-11e7-9c5c-17d6d867b050.png)

I am reloading like crazy and I can't reproduce the issue after this change so  either I am very lucky or it fixed the issue 😀 
