### PR TITLE
add temporary solution for linking to classes from different project

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -19,6 +19,7 @@ export default JSONAPIAdapter.extend({
   currentProjectVersion: '',
 
   metaStore: service(),
+  projectService: service('project'),
 
   async findRecord(store, {modelName}, id) {
     let url;
@@ -30,7 +31,7 @@ export default JSONAPIAdapter.extend({
       let revId = this.get('metaStore').getRevId(projectName, version, modelName, id);
       url = `json-docs/${projectName}/${version}/${inflector.pluralize(modelName)}/${revId}`;
     } else if (modelName === 'missing') {
-      let version = Ember.getOwner(this).lookup('controller:project-version').get('model.version');
+      let version = this.get('projectService.version');
       let revId = this.get('metaStore').getRevId(projectName, version, modelName, id);
       url = `json-docs/${projectName}/${version}/${inflector.pluralize(modelName)}/${revId}`;
     } else if (modelName === 'project') {

--- a/app/models/class.js
+++ b/app/models/class.js
@@ -4,6 +4,34 @@ import Ember from 'ember';
 const {computed} = Ember;
 const {attr, belongsTo} = DS;
 
+const projectNameFromClassName = key => {
+  return computed(key, function() {
+    const value = this.get(key) || "";
+    if (value.indexOf('Ember.') > -1) {
+      return 'ember';
+    }
+
+    if (value.indexOf('DS.') > 1) {
+      return 'ember-data';
+    }
+
+    return this.get('project.id');
+  });
+};
+
+// ideally this computed property would not be needed and we'd have extendsVersion, extendsProject attrs from json-api-docs
+const guessVersionFor = key => {
+  return computed(key, 'project.id', function() {
+
+    if (this.get('extendedClassProjectName') === this.get('project.id')) {
+      return this.get('projectVersion.version');
+    }
+
+    // try linking to latest version at least
+    return 'release';
+  });
+};
+
 export default DS.Model.extend({
   name: attr(),
   methods: attr(),
@@ -21,6 +49,11 @@ export default DS.Model.extend({
   projectVersion: belongsTo('project-version', {inverse: 'classes'}),
   project: computed('projectVersion.id', function() {
     return this.get('projectVersion').get('project');
-  })
+  }),
+
+  extendedClassProjectName: projectNameFromClassName('extends'),
+  extendedClassVersion: guessVersionFor('extends'),
+  usedClassProjectName: projectNameFromClassName('uses'),
+  usedClassVersion: guessVersionFor('uses')
 
 });

--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -8,7 +8,7 @@
     {{#if model.extends}}
       <div class="attribute">
         <span class="attribute-label">Extends:</span>
-        <span class="attribute-value">{{#link-to 'project-version.classes.class' model.projectVersion.version model.extends}}{{model.extends}}{{/link-to}}</span>
+        <span class="attribute-value">{{#link-to 'project-version.classes.class' model.extendedClassProjectName model.extendedClassVersion model.extends}}{{model.extends}}{{/link-to}}</span>
       </div>
     {{/if}}
     {{#if model.uses}}
@@ -17,7 +17,7 @@
         <span class="attribute-value">
           {{#each model.uses as |parentClass idx|}}
             {{#unless (eq idx 0)}}<span class="comma">,</span>{{/unless}}
-            {{#link-to 'project-version.classes.class' model.projectVersion.version parentClass}}{{parentClass}}{{/link-to}}
+            {{#link-to 'project-version.classes.class' model.usedClassProjectName model.usedClassVersion parentClass}}{{parentClass}}{{/link-to}}
           {{/each}}
         </span>
       </div>


### PR DESCRIPTION
A temporary and dirty solution for #243.

Ideally, the properties that are currently computed properties on the class model would be provided by `ember-json-api-docs`.

Another option would to transform `uses` and `extends` into relationships. But that could result in extra network requests... or JSON-API could take care of that via `include`?