### PR TITLE
[wip]Support fastboot plus hash params

### DIFF
--- a/app/routes/project-version/classes/class/index.js
+++ b/app/routes/project-version/classes/class/index.js
@@ -1,6 +1,0 @@
-import Ember from 'ember';
-import HashRedirectMixin from '../../../../mixins/hash-redirect';
-
-export default Ember.Route.extend(HashRedirectMixin, {
-  templateName: 'class-index'
-});

--- a/app/routes/project-version/classes/class/index.js
+++ b/app/routes/project-version/classes/class/index.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  templateName: 'class-index'
+});

--- a/app/routes/project-version/namespaces/namespace/index.js
+++ b/app/routes/project-version/namespaces/namespace/index.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-import HashRedirectMixin from 'ember-api-docs/mixins/hash-redirect';
-
-export default Ember.Route.extend(HashRedirectMixin, {
-  templateName: 'class-index'
-
-});

--- a/app/routes/project-version/namespaces/namespace/index.js
+++ b/app/routes/project-version/namespaces/namespace/index.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  templateName: 'class-index'
+});

--- a/lib/hash-to-query/index.js
+++ b/lib/hash-to-query/index.js
@@ -1,0 +1,41 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = {
+  name: 'hash-to-query',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+
+  contentFor (type, config) {
+    if (type === 'body') {
+      return `
+<script type='text/javascript'>
+  let hash = window.location.hash;
+  if (hash && hash.length > 1) {
+    let pathName = window.location.pathname;
+    console.log(pathName);
+    if (!pathName.includes('/methods/') &&
+        !pathName.includes('/properties/') &&
+        !pathName.includes('/events/')) {
+      let type = hash.slice(1, hash.indexOf('_'));
+      let name = hash.slice(hash.indexOf('_') + 1, hash.length);
+      let anchor = '?anchor=' + name + '&show=inherited,protected,private,deprecated';
+      let newPath = pathName;
+      if (type === 'method') {
+        newPath = pathName + '/methods/' + name;
+      } else if (type === 'property') {
+        newPath = pathName + '/properties/' + name;
+      } else if (type === 'event') {
+        newPath = pathName + '/events/' + name;
+      }
+      window.location.href = window.location.origin + newPath + anchor;
+    }
+  }
+</script>
+`
+    }
+    return '';
+  }
+};

--- a/lib/hash-to-query/package.json
+++ b/lib/hash-to-query/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "hash-to-query",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -92,5 +92,10 @@
     "fastboot-app-server": "1.0.0-rc.5",
     "loader.js": "^4.4.1",
     "minimist": "^1.2.0"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/hash-to-query"
+    ]
   }
 }


### PR DESCRIPTION
Since hash params aren't sent to the server, and since route model hooks aren't run client side with fastboot.  I'm "cheating" here and inserting a script that converts the hash for legacy urls.  I'm doing this via implementing `contentFor` in an in-repo-addon.