### PR TITLE
rely on ember-cli-head to set document title

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,6 @@
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Ember API Documentation</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="{{rootURL}}assets/images/favicon.png">

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,7 +5,7 @@ const { set, inject } = Ember;
 
 export default Ember.Route.extend({
   headData: inject.service(),
-  title: function(tokens) {
+  title(tokens) {
     const reversed = Ember.makeArray(tokens).reverse();
     const title = `${reversed.join(' - ')} - Ember API Documentation`;
     set(this, 'headData.title', title);

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,4 +1,7 @@
+<title>{{model.title}}</title>
+
 <link rel="dns-prefetch" href="{{cdnDomain}}" >
+
 <meta property="og:title" content={{model.title}} >
 <meta property="og:image" content="assets/images/ember-logo.png" >
 <meta property="og:image:width" content="1200" >


### PR DESCRIPTION
fixes #244

At this point, both `ember-cli-head` and `ember-cli-document-title` is used to set the `title`. Ideally `ember-cli-document-title` would be removed but its function for collecting tokens is quite useful so I'm not removing it so far. 


