### PR TITLE
support old IE browsers in url hash processing js

### DIFF
--- a/lib/hash-to-query/index.js
+++ b/lib/hash-to-query/index.js
@@ -12,17 +12,16 @@ module.exports = {
     if (type === 'body') {
       return `
 <script type='text/javascript'>
-  let hash = window.location.hash;
+  var hash = window.location.hash;
   if (hash && hash.length > 1) {
-    let pathName = window.location.pathname;
-    console.log(pathName);
-    if (!pathName.includes('/methods/') &&
-        !pathName.includes('/properties/') &&
-        !pathName.includes('/events/')) {
-      let type = hash.slice(1, hash.indexOf('_'));
-      let name = hash.slice(hash.indexOf('_') + 1, hash.length);
-      let anchor = '?anchor=' + name + '&show=inherited,protected,private,deprecated';
-      let newPath = pathName;
+    var pathName = window.location.pathname;
+    if (pathName.indexOf('/methods/') === -1 &&
+        pathName.indexOf('/properties/') === -1 &&
+        pathName.indexOf('/events/') === -1) {
+      var type = hash.slice(1, hash.indexOf('_'));
+      var name = hash.slice(hash.indexOf('_') + 1, hash.length);
+      var anchor = '?anchor=' + name + '&show=inherited,protected,private,deprecated';
+      var newPath = pathName;
       if (type === 'method') {
         newPath = pathName + '/methods/' + name;
       } else if (type === 'property') {


### PR DESCRIPTION
I assume we support old IEs (IE 9+) by looking at
![image](https://user-images.githubusercontent.com/3609063/27929130-b6b67d10-625f-11e7-8581-3c465aee2d65.png)

therefore I'm tweaking some of the raw javascript I had to stick in for hash processing.

cc @MartinMalinda 