### PR TITLE
Set up scroll container element selector in config

### DIFF
--- a/app/services/scroll-position-reset.js
+++ b/app/services/scroll-position-reset.js
@@ -1,4 +1,8 @@
 import Ember from 'ember';
+import config from 'ember-api-docs/config/environment';
+
+const { scrollContainerElement } = config.APP;
+
 
 const {$} = Ember;
 
@@ -24,7 +28,7 @@ export default Ember.Service.extend({
 
   doReset() {
     if (this.get('_shouldResetScroll')) {
-      $('section.content').scrollTop(0);
+      $(scrollContainerElement).scrollTop(0);
       this.set('_shouldResetScroll', false);
     }
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,6 +23,7 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      scrollContainerElement: 'body'
     },
 
     fastboot: {
@@ -57,6 +58,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.scrollContainerElement = '#ember-testing-container';
   }
 
   ENV.contentSecurityPolicy = {

--- a/tests/acceptance/scroll-reset-on-transition-test.js
+++ b/tests/acceptance/scroll-reset-on-transition-test.js
@@ -1,64 +1,68 @@
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import Ember from 'ember';
 import { visit } from 'ember-native-dom-helpers';
+import config from 'ember-api-docs/config/environment';
 
 const { $ } = Ember;
 
+const { scrollContainerElement } = config.APP;
+
 moduleForAcceptance('Acceptance | scroll reset on transition');
 
-skip('reset scroll on transitions', async function(assert) {
+test('reset scroll on transitions', async function(assert) {
   await visit('/');
 
-  $('section.content').scrollTop(1000);
-  assert.notEqual($('section.content').scrollTop(), 0, 'scroll position is NOT zero after scroll on fresh visit');
+  $(scrollContainerElement).scrollTop(1000);
+  assert.notEqual($(scrollContainerElement).scrollTop(), 0, 'scroll position is NOT zero after scroll on fresh visit');
 
   await visit('/ember/1.0/classes/Ember.View');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is zero after transition to different route');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is zero after transition to different route');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('/ember/1.0/classes/Ember.Component');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after transition: project.version.class.index to project-version.class.index (same route different model)');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after transition: project.version.class.index to project-version.class.index (same route different model)');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/modules/ember');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after transition: project-version.class.index to project-version.module.index');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after transition: project-version.class.index to project-version.module.index');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/modules/runtime');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after transition: project-version.module.index to project-version.module.index (same route different model)');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after transition: project-version.module.index to project-version.module.index (same route different model)');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/namespaces/Ember');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after transition: project-version.module.index to project-version.namespace.index');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after transition: project-version.module.index to project-version.namespace.index');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/namespaces/Ember.run');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after transition: project-version.namespace.index to project-version.namespace.index (same route different model)');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after transition: project-version.namespace.index to project-version.namespace.index (same route different model)');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/classes/Ember.RenderBuffer/');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after transition: project-version.namespace.index to project-version.class.index');
-  $('section.content').scrollTop(1000);
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after transition: project-version.namespace.index to project-version.class.index');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/classes/Ember.RenderBuffer/properties');
 
-  assert.notEqual($('section.content').scrollTop(), 0, 'scroll position is NOT resetted after changing tab in project-version.class (properties)');
-  $('section.content').scrollTop(1000);
+
+  assert.notEqual($(scrollContainerElement).scrollTop(), 0, 'scroll position is NOT resetted after changing tab in project-version.class (properties)');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/classes/Ember.RenderBuffer/methods');
 
-  assert.notEqual($('section.content').scrollTop(), 0, 'scroll position is NOT resetted after changing tab in project-version.class (methods)');
-  $('section.content').scrollTop(1000);
+  assert.notEqual($(scrollContainerElement).scrollTop(), 0, 'scroll position is NOT resetted after changing tab in project-version.class (methods)');
+  $(scrollContainerElement).scrollTop(1000);
 
   await visit('ember/1.0/classes/Ember.Route/methods');
 
-  assert.equal($('section.content').scrollTop(), 0, 'scroll position is resetted after visiting route with same tab but different model');
+  assert.equal($(scrollContainerElement).scrollTop(), 0, 'scroll position is resetted after visiting route with same tab but different model');
 });


### PR DESCRIPTION
Fixes #273

Previously, the srolling was done on `section.content` probably via `overflow:scroll`. Seems like the styles changed and the scrolling is done on root element again.