### PR TITLE
Enhancement: Inherited as default in class page

### DIFF
--- a/app/mixins/filter-params.js
+++ b/app/mixins/filter-params.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const {
   Mixin, get, set, computed, A,
-  String: { capitalize, w },
+  String: { capitalize },
   inject: { service },
   isEmpty
 } = Ember;
@@ -13,17 +13,17 @@ const DEFAULT_FILTER = 'inherited';
 export default Mixin.create({
   filterData: service(),
 
-  queryParams: [{visibilityFilter: 'show'}],
+  queryParams: [{ visibilityFilter: 'show' }],
 
   visibilityFilter: computed(
     'filterData.{showInherited,showProtected,showPrivate,showDeprecated}',
     {
       get() {
         let appliedFilters = filterTypes.reduce((filters, filter) => {
-          let filterValue = get(this, `filterData.show${capitalize(filter)}`) ? filter: null;
-          filters.push(filterValue)
+          let filterValue = get(this, `filterData.show${capitalize(filter)}`) ? filter : null;
+          filters.push(filterValue);
           return filters;
-        }, A()).compact()
+        }, A()).compact();
 
         if (isEmpty(appliedFilters)) {
           return DEFAULT_FILTER;
@@ -34,9 +34,9 @@ export default Mixin.create({
       set(key, value = '') {
         let filters = A(value.split(','));
         filterTypes.forEach(filter => {
-            let enabled = filters.includes(filter);
-            set(this, `filterData.show${capitalize(filter)}`, enabled);
-          });
+          let enabled = filters.includes(filter);
+          set(this, `filterData.show${capitalize(filter)}`, enabled);
+        });
         return value;
       }
     }

--- a/tests/acceptance/class-test.js
+++ b/tests/acceptance/class-test.js
@@ -38,7 +38,7 @@ test('lists all the events on the class page', function (assert) {
 
 test('has query params for access visibilities', function (assert) {
   let params = (currentURL().match(/show=([\w\d%]*)/)[1] || '').split('%2C');
-  assert.ok(params.includes('inherited'), 'show param includes inherited');
+  assert.notOk(params.includes('inherited'), 'show param does not include inherited because it is the default and we unselected it');
   assert.ok(params.includes('protected'), 'show param includes protected');
   assert.ok(params.includes('private'), 'show param includes private');
   assert.ok(params.includes('deprecated'), 'show param includes deprecated');


### PR DESCRIPTION
Fixes #278 


Doing it this way means you can only unselect all if you unselect inherited, as it will always defaults back to inherited if you go to unselect the last remaining filter type.
Not sure if this is a problem.