### PR TITLE
Make anchors work again

### DIFF
--- a/app/components/ember-anchor.js
+++ b/app/components/ember-anchor.js
@@ -1,5 +1,6 @@
 import AnchorComponent from 'ember-anchor/components/ember-anchor';
 import Ember from 'ember';
+import config from 'ember-api-docs/config/environment';
 
 const { $, get } = Ember;
 
@@ -12,8 +13,8 @@ export default AnchorComponent.extend({
     let elem = $(`[data-${qp}="${qpVal}"]`);
     let offset = (elem && elem.offset && elem.offset()) ? elem.offset().top : null;
     if (offset) {
-      let scrollOffset = this.$().scrollParent().offset().top - this.$().scrollParent().scrollTop();
-      this.$().scrollParent().scrollTop(offset - scrollOffset);
+      const navMenuHeight = $('header').outerHeight();
+      $(config.APP.scrollContainerElement).scrollTop(offset - navMenuHeight - 10);
     }
   }
 });


### PR DESCRIPTION
While the scroll reset on transitions was fixed, it did not fix the issue with anchors. The problem is the same though, the scrollable element has changed from `section.content` to `body`. 