### PR TITLE
omit line numbers when user selects code blocks (#286)

### DIFF
--- a/app/styles/components/_highlight.scss
+++ b/app/styles/components/_highlight.scss
@@ -168,3 +168,10 @@ a code {
 .CodeRay thead {
   background-color: #292929;
 }
+
+.CodeRay .line-numbers {
+  -webkit-user-select: none;  /* Chrome all / Safari all */
+  -moz-user-select: none;     /* Firefox all */
+  -ms-user-select: none;      /* IE 10+ */
+  user-select: none;          /* Likely future */
+}


### PR DESCRIPTION
Small CSS fix to make code blocks easier to copy & paste. Closes https://github.com/ember-learn/ember-api-docs/issues/286

I might add this to the Guides too. It's pretty nice.

@sivakumar-kailasam 