### PR TITLE
Mobile friendlier header, footer, and code blocks

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -12,14 +12,10 @@ body {
   width: 100%;
 }
 
-.header {
-  z-index: 2;
-}
-@include media($medium-large-screen-up) {
+@include media($large-screen-up) {
   .header {
     top: 0;
     width: 100%;
-    position: fixed;
   }
 
   main.container {
@@ -29,7 +25,6 @@ body {
   main.container .content {
     position: relative;
     margin-right: 0;
-    margin-top: $top-spacing;
     margin-bottom: 0;
     overflow:auto;
     padding: $base-spacing;

--- a/app/styles/components/_article.scss
+++ b/app/styles/components/_article.scss
@@ -93,7 +93,6 @@ article {
   @media (max-width: $medium-screen) {
     table {
       td,th {
-        display: block;
         border: 0;
       }
 

--- a/app/styles/components/_footer.scss
+++ b/app/styles/components/_footer.scss
@@ -14,7 +14,7 @@
   border-bottom: none;
 }
 
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $medium-screen) {
   .responsive.footer .container {
     padding: 2rem 1rem;
 
@@ -60,7 +60,7 @@
   display: flex
 }
 
-@media screen and (max-width: 40rem) {
+@media screen and (max-width: $large-screen) {
   .responsive.footer .container {
     text-align: center;
     display: block;
@@ -82,7 +82,7 @@
   text-align: left
 }
 
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .responsive.footer .footer-info {
     text-align: center;
   }
@@ -130,7 +130,7 @@
   max-height: 45px;
 }
 
-@media screen and (min-width: 53.75rem) {
+@media screen and (min-width: $large-screen) {
   .footer .footer-contributions {
     display: flex;
     flex:0 0 21em;
@@ -152,7 +152,7 @@
   }
 }
 
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .footer .footer-social a:first-child {
     margin-left: 0;
   }

--- a/app/styles/components/_footer.scss
+++ b/app/styles/components/_footer.scss
@@ -15,7 +15,7 @@
 }
 
 @media screen and (max-width: 53.75rem) {
-  .responsive .footer .container {
+  .responsive.footer .container {
     padding: 2rem 1rem;
 
     .footer-info {
@@ -60,8 +60,8 @@
   display: flex
 }
 
-@media screen and (max-width: 53.75rem) {
-  .responsive .footer .container {
+@media screen and (max-width: 40rem) {
+  .responsive.footer .container {
     text-align: center;
     display: block;
   }
@@ -83,15 +83,15 @@
 }
 
 @media screen and (max-width: 53.75rem) {
-  .responsive .footer .footer-info {
+  .responsive.footer .footer-info {
     text-align: center;
   }
 
-  .responsive .footer .footer-statement {
+  .responsive.footer .footer-statement {
     text-align: center;
   }
 
-  .responsive .footer .footer-tagline {
+  .responsive.footer .footer-tagline {
     padding-left: 2em;
     padding-right: 2em;
   }

--- a/app/styles/components/_header.scss
+++ b/app/styles/components/_header.scss
@@ -43,7 +43,7 @@ $white: white;
   display: -webkit-flex;
 }
 
-@media screen and (max-width: $medium-screen) {
+@media screen and (max-width: $large-screen) {
   .responsive.header .container {
     display: block;
   }
@@ -55,7 +55,7 @@ $white: white;
   justify-content: space-between;
   height: 2.8rem;
 }
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .responsive.header .header-nav {
     height: auto;
   }
@@ -69,7 +69,7 @@ $white: white;
   width: 100%;
 }
 
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .responsive.header a {
     line-height: 24px; //do we need this
   }
@@ -90,12 +90,12 @@ $white: white;
   text-align: center;
 }
 
-@media screen and (max-width: 53.75em) {
+@media screen and (max-width: $large-screen) {
   .responsive .header-nav li {
     display: inherit;
   }
 }
-@media screen and (max-width: 53.75em) {
+@media screen and (max-width: $large-screen) {
   .responsive .header-nav li:not(.header-logo):not(.header-search) {
     width: 32%;
     display: inline-block;
@@ -105,8 +105,6 @@ $white: white;
 
 .header-nav li:not(.header-logo):not(.header-search) {
   width: auto;
-}
-@media screen and (min-width: 53.75rem) {
 }
 
 .header-nav .header-logo {
@@ -119,7 +117,7 @@ $white: white;
   flex: 1.5 0 0;
 }
 
-@media screen and (min-width: 53.75rem) {
+@media screen and (min-width: $large-screen) {
 }
 
 .header-nav .header-search {
@@ -132,7 +130,7 @@ $white: white;
   flex: 2 0 0;
 }
 
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .responsive .header-nav .header-search {
     display: block;
   }
@@ -147,7 +145,7 @@ $white: white;
   display: block;
 }
 
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .responsive .header-logo a {
     margin: 0 auto;
   }
@@ -193,7 +191,7 @@ $white: white;
     color: white;
   }
 }
-@media screen and (max-width: 53.75rem) {
+@media screen and (max-width: $large-screen) {
   .responsive .header-search {
     margin-left: 0;
   }

--- a/app/styles/components/_header.scss
+++ b/app/styles/components/_header.scss
@@ -43,8 +43,8 @@ $white: white;
   display: -webkit-flex;
 }
 
-@media screen and (max-width: 53.75rem) {
-  .responsive .header .container {
+@media screen and (max-width: $medium-screen) {
+  .responsive.header .container {
     display: block;
   }
 }
@@ -56,7 +56,7 @@ $white: white;
   height: 2.8rem;
 }
 @media screen and (max-width: 53.75rem) {
-  .responsive .header .header-nav {
+  .responsive.header .header-nav {
     height: auto;
   }
 }
@@ -70,7 +70,7 @@ $white: white;
 }
 
 @media screen and (max-width: 53.75rem) {
-  .responsive .header a {
+  .responsive.header a {
     line-height: 24px; //do we need this
   }
 }

--- a/app/styles/components/_highlight.scss
+++ b/app/styles/components/_highlight.scss
@@ -42,6 +42,7 @@
     margin: 0;
     table-layout: auto;
     width: 100%;
+    z-index: auto;
 
     tr,
     th,

--- a/app/styles/components/_sidebar.scss
+++ b/app/styles/components/_sidebar.scss
@@ -5,7 +5,11 @@
   z-index: 1;
   padding: $small-spacing 0;
 
-  @include media($medium-large-screen-up) {
+  @include media($medium-screen-up) {
+    margin-top: 5em;
+  }
+
+  @include media($large-screen-up) {
     // fixed sidebar, full height
     @include span-columns(3.5);
     margin-right: 0;

--- a/app/styles/components/_sidebar.scss
+++ b/app/styles/components/_sidebar.scss
@@ -6,7 +6,7 @@
   padding: $small-spacing 0;
 
   @include media($medium-screen-up) {
-    margin-top: 5em;
+    margin-top: 11em;
   }
 
   @include media($large-screen-up) {

--- a/app/styles/components/_sidebar.scss
+++ b/app/styles/components/_sidebar.scss
@@ -5,10 +5,6 @@
   z-index: 1;
   padding: $small-spacing 0;
 
-  @include media($medium-screen-up) {
-    margin-top: 11em;
-  }
-
   @include media($large-screen-up) {
     // fixed sidebar, full height
     @include span-columns(3.5);
@@ -17,7 +13,6 @@
     border-bottom: 0;
     border-right: $base-border;
     padding: $small-spacing $base-spacing $base-spacing * 1.5;
-    margin-top: 5em;
 
     &::before {
       @include position(absolute, 0 0 0 -100vw);

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<header class="header">
+<header class="header responsive">
   <nav role="navigation" aria-label="main">
     <ul class="header-nav container">
       <li class="header-logo">

--- a/app/templates/components/main-footer.hbs
+++ b/app/templates/components/main-footer.hbs
@@ -1,4 +1,4 @@
-<div class="footer">
+<div class="footer responsive">
   <div class="container">
     <div class="footer-info">
       Copyright {{currentYear}}


### PR DESCRIPTION
Closes https://github.com/ember-learn/ember-api-docs/issues/317 and maybe https://github.com/ember-learn/ember-api-docs/issues/274

**Sidebar bug:** I brought in the media query breaks just a bit, to align the sidebar behavior with the container. This means it jumps into mobile arrangement sooner. 

**Responsive header/footer:** The main problem was that all the responsive CSS ported over from the main site wasn't being applied because that class was was not included in the html.

**Coderay block separating from line numbers:** just a global-ish css rule on tables that didn't make sense.

**Coderay block selection**: in the more global CSS was a `z-index: -1` applied to table layouts, which had an unexpected effect on code blocks. Setting the z index back to normal for coderay tables fixes the cursor problem. TBD whether code can be copied & pasted in mobile.