### PR TITLE
styles: parameter and return type tweaks

### DIFF
--- a/app/styles/components/_class-field-desc.scss
+++ b/app/styles/components/_class-field-desc.scss
@@ -17,11 +17,14 @@
   font-size: $base-font-size;
 }
 
-.return-type {
+.class-field-description--link .return-type,
+.return .return-type,
+.parameter .parameter-type {
   color: $medium-gray;
   font-style: italic;
   font-weight: normal;
   font-size: $base-font-size;
+  margin-right: 5px;
 }
 
 .access {
@@ -42,6 +45,13 @@
   dd {
     display: inline-block;
   }
+}
+
+.return .return-type,
+.parameter .parameter-type {
+  color: #bd695b;
+  font-style: italic;
+  margin-right: 5px;
 }
 
 .method, .property, .event {

--- a/app/styles/components/_class-field-desc.scss
+++ b/app/styles/components/_class-field-desc.scss
@@ -47,13 +47,6 @@
   }
 }
 
-.return .return-type,
-.parameter .parameter-type {
-  color: #bd695b;
-  font-style: italic;
-  margin-right: 5px;
-}
-
 .method, .property, .event {
   border-bottom: $base-border;
 

--- a/app/templates/components/class-field-description.hbs
+++ b/app/templates/components/class-field-description.hbs
@@ -36,14 +36,14 @@
     {{#each field.params as |param|}}
       <div class="parameter">
         <dt>{{param.name}}</dt>
-        <dd>{{param.type}}</dd>
+        <dd class="parameter-type">{{param.type}}</dd>
         <dd>{{param.description}}</dd>
       </div>
     {{/each}}
     {{#if field.return}}
       <div class="return">
         <dt>returns</dt>
-        <dd>{{field.return.type}}</dd>
+        <dd class="return-type">{{field.return.type}}</dd>
         <dd>{{field.return.description}}</dd>
       </div>
     {{/if}}


### PR DESCRIPTION
Make it more obvious where the type ends and the description begins. I didn't check this locally.

Looks something like this:

![screen shot 2017-08-17 at 10 30 16 am](https://user-images.githubusercontent.com/34726/29417416-1b5ca88c-8337-11e7-8153-5cdabd905379.png)
