### PR TITLE
WIP bugfix: hide private API when following guides/legacy links (#307)

### DIFF
--- a/lib/hash-to-query/index.js
+++ b/lib/hash-to-query/index.js
@@ -20,7 +20,12 @@ module.exports = {
         pathName.indexOf('/events/') === -1) {
       var type = hash.slice(1, hash.indexOf('_'));
       var name = hash.slice(hash.indexOf('_') + 1, hash.length);
-      var anchor = '?anchor=' + name + '&show=inherited,protected,private,deprecated';
+      var anchor = '?anchor=' + name;
+      var queryParams = window.location.search;
+      var matchedQP = queryParams.match(/inherited|protected|private|deprecated/gi);
+      if (matchedQP) {
+        anchor += '&show=' + matchedQP.join(',');
+      }
       var newPath = pathName;
       if (type === 'method') {
         newPath = pathName + '/methods/' + name;


### PR DESCRIPTION
**WIP don't merge.**

Addresses https://github.com/ember-learn/ember-api-docs/issues/307

Based on conversation about hiding private API by default (https://github.com/ember-learn/ember-api-docs/issues/303), I think it makes sense that legacy urls should not show private api by default either.

Currently, links from the Guides redirect to showing all QPs (inherited, protected, private, deprecated), so new learners would see private API a lot. I fixed this by changing the legacy url processing.