### PR TITLE
Bump node version for travis to address #340

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6'
+- '8'
 
 dist: trusty
 sudo: false


### PR DESCRIPTION
I changed the node version in `travis.yml`. We possibly need to upgrade from Node 6 to 8 for CI, due to a breaking change in yarn that enforces engines, plus our need to be on Node v8 for app performance.

The alternative is to use `yarn install --ignore-engines` in Travis.

Addresses #340 which is blocking to all PRs in this repo.