### PR TITLE
set specific yarn version for travis CI (#340)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   yarn: true
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add bower
 


### PR DESCRIPTION
Patch in response to deploy failure after PR #341 

Error was:

> error An unexpected error occurred: "/tmp/build_8ef72fdc58af9b12ae86074f103a1cc4/node_modules/spawn-sync: EROFS: read-only file system, access '/usr/local/bin'".


This appears to be fixed in a Yarn patch: https://github.com/yarnpkg/yarn/pull/4325

This change follows version syntax specified here: https://yarnpkg.com/lang/en/docs/install/#alternatives-tab