### PR TITLE
fix loose matching of versions (#333)

### DIFF
--- a/app/services/meta-store.js
+++ b/app/services/meta-store.js
@@ -35,7 +35,13 @@ export default Service.extend({
 
   getFullVersion(projectName, compactProjVersion) {
     const availProjVersions = this.get(`availableProjectVersions.${projectName}`);
-    return availProjVersions.filter(v => v.includes(compactProjVersion))[0];
+    let filtered = availProjVersions.filter(function(v, index) {
+      // shorten versions to 2 digits and compare them. 2.15.0 becomes 2.15
+      let vTrimmed = v.split('.').slice(0,2).join('.')
+      let compactProjTrimmed = compactProjVersion.split('.').slice(0,2).join('.')
+      return vTrimmed === compactProjTrimmed
+    })
+    // return the full version number, like 2.15.2
+    return filtered[0]
   }
-
 });

--- a/tests/unit/services/meta-store-test.js
+++ b/tests/unit/services/meta-store-test.js
@@ -7,3 +7,14 @@ test('it exists', function(assert) {
   let service = this.subject();
   assert.ok(service);
 });
+
+test('correct version selected', function(assert) {
+  let service = this.subject();
+  service.set('availableProjectVersions.ember', ['2.15.0', '2.14.1', '2.13.4', '1.0.0', '1.1.2', '1.10.1', '1.11.4', '1.12.2', '1.13.13', '1.2.2', '1.3.2', '1.4.0', '1.5.1', '1.6.1', '1.7.1', '1.8.1', '1.9.1', '2.0.3', '2.1.2', '2.10.2', '2.11.3', '2.12.2', '2.13.3', '2.2.2', '2.3.2', '2.4.6', '2.5.1', '2.6.2', '2.7.3', '2.8.3', '2.9.1', '2.14.0']);
+  let matchA = service.getFullVersion('ember', '1.2')
+  let matchB = service.getFullVersion('ember', '1.1')
+  let matchC = service.getFullVersion('ember', '2.2')
+  assert.equal(matchA, '1.2.2')
+  assert.equal(matchB, '1.1.2')
+  assert.equal(matchC, '2.2.2')
+});


### PR DESCRIPTION
In the live site, choosing some `1.x` from the version dropdown will sometimes bring you to the wrong version docs or leave the dropdown in a weird state. In the old code, 1.2 would match 2.11.2, for example. This PR does a more careful match.

Issue: https://github.com/ember-learn/ember-api-docs/issues/333