### PR TITLE
Fix legacy redirects

### DIFF
--- a/app/routes/class.js
+++ b/app/routes/class.js
@@ -1,6 +1,6 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import getLastVersion from 'ember-api-docs/utils/get-last-version';
+//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
@@ -8,11 +8,20 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
       .then((project) => {
-        let versions = project.get('projectVersions').toArray();
-        let lastVersion = getLastVersion(versions);
+        //let versions = project.get('projectVersions').toArray();
+        //let lastVersion = getLastVersion(versions);
+        // Currently redirecting to last 2.15 version until we can map old
+        // Ember.* apis with rfc 176 items
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-${lastVersion}`, { includes: 'project' });
+      })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
         //peel off the .html
         let className = params['class'].substr(0, params['class'].lastIndexOf('.'));
         let id = `ember-${lastVersion}-${className}`;
+
         return hash({
           project: resolve(project),
           version: resolve(lastVersion),
@@ -35,8 +44,8 @@ export default Route.extend({
               return this.transitionTo('project-version');
             })
         });
-      })
-      .catch((e) => {
+
+      }).catch((e) => {
         return this.transitionTo('project-version');
       });
   },

--- a/app/routes/data-class.js
+++ b/app/routes/data-class.js
@@ -1,6 +1,6 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import getLastVersion from 'ember-api-docs/utils/get-last-version';
+//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
@@ -8,8 +8,14 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
       .then((project) => {
-        let versions = project.get('projectVersions').toArray();
-        let lastVersion = getLastVersion(versions);
+        // let versions = project.get('projectVersions').toArray();
+        // let lastVersion = getLastVersion(versions);
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
+      })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
         let className = params['class'].substr(0, params['class'].lastIndexOf('.'));
         let id = `ember-data-${lastVersion}-${className}`;
         return hash({

--- a/app/routes/data-module.js
+++ b/app/routes/data-module.js
@@ -1,6 +1,6 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import getLastVersion from 'ember-api-docs/utils/get-last-version';
+//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
@@ -8,17 +8,23 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
       .then((project) => {
-        let versions = project.get('projectVersions').toArray();
-        let lastVersion = getLastVersion(versions);
+        // let versions = project.get('projectVersions').toArray();
+        // let lastVersion = getLastVersion(versions);
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
+      })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
         let className = params['module'].substr(0, params['module'].lastIndexOf('.'));
         let id = `ember-data-${lastVersion}-${className}`;
         return hash({
           project: resolve(project),
           version: resolve(lastVersion),
-          classData: this.store.find('class', id)
+          classData: this.store.find('module', id)
             .then((classData) => {
               return {
-                type: 'class',
+                type: 'module',
                 data: classData
               };
             })
@@ -26,6 +32,9 @@ export default Route.extend({
               return this.transitionTo('project-version');
             })
         });
+
+      }).catch((e) => {
+        return this.transitionTo('project-version');
       });
   },
 

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -1,6 +1,6 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import getLastVersion from 'ember-api-docs/utils/get-last-version';
+//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 
 import { pluralize } from 'ember-inflector';
 
@@ -9,19 +9,30 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
       .then(project => {
-        let versions = project.get('projectVersions').toArray();
-        let lastVersion = getLastVersion(versions);
+        // let versions = project.get('projectVersions').toArray();
+        // let lastVersion = getLastVersion(versions);
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-${lastVersion}`, { includes: 'project' });
+      })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
         let className = params['module'].substr(0, params['module'].lastIndexOf('.'));
         let id = `ember-${lastVersion}-${className}`;
 
         return hash({
           project: resolve(project),
           version: resolve(lastVersion),
-          classData: this.store.find('module', id).then(classData => {
-            return { type: 'module', data: classData };
-          })
+          classData: this.store.find('module', id)
+            .then(classData => {
+              return { type: 'module', data: classData };
+            })
+            .catch((e) => {
+              return this.transitionTo('project-version');
+            })
 
         });
+
       }).catch((e) => {
         return this.transitionTo('project-version');
       });


### PR DESCRIPTION
Fixes part of #355 

oddly enough, this doesn't look like it was broke by 2.16.  At some point we changed to fetching project revisions to determine fingerprinted releases.  these routes weren't updated for that new sequence, so all i'm doing here is adding the followup fetch of project-version rev file.

Currently hard coding to 2.15.3 until we can add mapping code.