### PR TITLE
put back most tests after 2.16 modules #367

### DIFF
--- a/tests/acceptance/analytics-page-tracking-test.js
+++ b/tests/acceptance/analytics-page-tracking-test.js
@@ -1,12 +1,12 @@
 import { run } from '@ember/runloop';
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import { visit } from 'ember-native-dom-helpers';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import { requestIdlePromise } from 'ember-api-docs/utils/request-idle-callback';
 
 moduleForAcceptance('Acceptance | analytics page tracking');
 
-skip('checking that trackPage gets called on transitions', async function(assert) {
+test('checking that trackPage gets called on transitions', async function(assert) {
 
   const pages = ['/ember/2.11/namespaces/Ember', '/ember/2.11/modules/ember-metal', '/ember/2.11/classes/Ember.Application'];
   const pagesClone = pages.slice(0);

--- a/tests/acceptance/method-inheritance-test.js
+++ b/tests/acceptance/method-inheritance-test.js
@@ -1,16 +1,16 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
-import {skip} from 'qunit';
+import { test } from 'qunit';
 import { visit, click, findWithAssert } from 'ember-native-dom-helpers';
 import testSelector from 'ember-test-selectors';
 
 moduleForAcceptance('Acceptance | method inheritance')
 
-skip('no duplicate methods displayed', async function (assert) {
+test('no duplicate methods displayed', async function (assert) {
   await visit('/ember-data/2.14/classes/DS.JSONAPIAdapter');
   assert.dom("[data-test-item='createRecord']").exists({ count: 1 });
 });
 
-skip('most local inherited method is shown', async function (assert) {
+test('most local inherited method is shown', async function (assert) {
   await visit('/ember-data/2.14/classes/DS.JSONAPIAdapter');
   await click(`${testSelector('item', 'createRecord')} a`)
   assert.ok(findWithAssert("[data-test-file='addon/adapters/rest.js']"));

--- a/tests/acceptance/module-test.js
+++ b/tests/acceptance/module-test.js
@@ -1,10 +1,10 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import { visit, click } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | Module');
 
-skip('lists all public/private classes and namespaces on the module page', async function(assert) {
+test('lists all public/private classes and namespaces on the module page', async function(assert) {
   await visit('ember/1.0/modules/ember-handlebars');
 
   const store = this.application.__container__.lookup('service:store');
@@ -20,7 +20,7 @@ skip('lists all public/private classes and namespaces on the module page', async
   assert.equal(find('.spec-property-list li').length, numberPublicClasses + numberNameSpaces + numberPrivateClasses);
 });
 
-skip('lists all submodules on the module page', async function(assert) {
+test('lists all submodules on the module page', async function(assert) {
   await visit('ember/1.0/modules/ember');
 
   const store = this.application.__container__.lookup('service:store');
@@ -31,7 +31,7 @@ skip('lists all submodules on the module page', async function(assert) {
   assert.equal(find('.spec-method-list li').length, numberSubModules);
 });
 
-skip('display submodule parent', async function(assert) {
+test('display submodule parent', async function(assert) {
   await visit('ember/1.0/modules/ember-application');
 
   const store = this.application.__container__.lookup('service:store');

--- a/tests/acceptance/percy-test.js
+++ b/tests/acceptance/percy-test.js
@@ -1,11 +1,11 @@
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import { visit } from 'ember-native-dom-helpers';
 import { percySnapshot } from 'ember-percy';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | percy');
 
-skip('Percy snapshot tests', async function(assert) {
+test('Percy snapshot tests', async function(assert) {
   await visit('/');
   percySnapshot('Landing page');
   assert.ok(true);

--- a/tests/acceptance/redirects-test.js
+++ b/tests/acceptance/redirects-test.js
@@ -1,30 +1,29 @@
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import getLastVersion from 'ember-api-docs/utils/get-last-version';
 import { visit } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | redirects');
 
-skip('visiting /', async function(assert) {
+test('visiting /', async function(assert) {
   await visit('/');
 
   const store = this.application.__container__.lookup('service:store');
   let versions = store.peekAll('project-version').toArray();
   const last = getLastVersion(versions).split('.').slice(0, 2).join('.');
-
   assert.equal(
     currentURL(),
-    `/ember/${last}/namespaces/Ember`,
+    `/ember/${last}/modules/@ember%2Fapplication`,
     'routes to the latest version of the project'
   );
 });
 
-skip('visiting /:project/:project_version/classes', async function(assert) {
-  await visit('/ember/1.0/classes');
+test('visiting pre-2.16 version', async function(assert) {
+  await visit('/ember/1.0');
 
   assert.equal(
     currentURL(),
-    '/ember/1.0/namespaces/Ember',
-    'routes to the first namespace of the project-version'
+    '/ember/1.0/modules/ember',
+    'routes to the first module of the project-version'
   );
 });

--- a/tests/acceptance/scroll-reset-on-transition-test.js
+++ b/tests/acceptance/scroll-reset-on-transition-test.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import { visit } from 'ember-native-dom-helpers';
 import config from 'ember-api-docs/config/environment';
@@ -8,7 +8,7 @@ const { scrollContainerSelector } = config.APP;
 
 moduleForAcceptance('Acceptance | scroll reset on transition');
 
-skip('reset scroll on transitions', async function(assert) {
+test('reset scroll on transitions', async function(assert) {
   await visit('/');
 
   $(scrollContainerSelector).scrollTop(1000);

--- a/tests/acceptance/sidebar-nav-test.js
+++ b/tests/acceptance/sidebar-nav-test.js
@@ -1,4 +1,4 @@
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import { visit, click } from 'ember-native-dom-helpers';
 import testSelector from 'ember-test-selectors';
 
@@ -6,21 +6,21 @@ import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-accepta
 
 moduleForAcceptance('Acceptance | sidebar navigation');
 
-skip('can navigate to namespace from sidebar', async function(assert) {
+test('can navigate to namespace from sidebar', async function(assert) {
   await visit('/ember/1.0');
   await click(`${testSelector('namespace', 'Ember.String')} a`);
 
   assert.equal(currentURL(), '/ember/1.0/namespaces/Ember.String', 'navigated to namespace');
 });
 
-skip('can navigate to module from sidebar', async function(assert) {
+test('can navigate to module from sidebar', async function(assert) {
   await visit('/ember/1.0');
   await click(`${testSelector('module', 'ember-application')} a`);
 
   assert.equal(currentURL(), '/ember/1.0/modules/ember-application', 'navigated to module');
 });
 
-skip('can navigate to class from sidebar', async function(assert) {
+test('can navigate to class from sidebar', async function(assert) {
   await visit('/ember/1.0');
   await click(`${testSelector('class', 'Ember.Component')} a`);
 

--- a/tests/acceptance/switch-project-test.js
+++ b/tests/acceptance/switch-project-test.js
@@ -1,5 +1,5 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import {
   visit,
   click,
@@ -10,7 +10,7 @@ import $ from 'jquery';
 
 moduleForAcceptance('Acceptance | Switch Project');
 
-skip('Can switch projects back and forth', async function(assert) {
+test('Can switch projects back and forth', async function(assert) {
   async function ensureVersionsExist() {
     await selectSearch('.select-container', '2');
 

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -1,11 +1,11 @@
-import { skip } from 'qunit';
+import { test, skip } from 'qunit';
 import { visit } from 'ember-native-dom-helpers';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | version navigation');
 
-skip('switching versions', async function(assert) {
+test('switching versions 1.x', async function(assert) {
   // Classes
 
   await visit('/ember/1.0/classes/Ember.Component');
@@ -17,16 +17,19 @@ skip('switching versions', async function(assert) {
   await selectChoose('.select-container', '1.0');
   assert.equal(currentURL(), '/ember/1.0/classes/Ember.Component', 'navigated to v1.0 class');
 
+})
+
+skip('switching versions 2.x', async function(assert) {
   // Namespaces
 
-  await visit('/ember/2.7/namespaces/Ember.String');
-  assert.equal(currentURL(), '/ember/2.7/namespaces/Ember.String', 'navigated to v2.7 namespace');
+  await visit('/ember/2.7/classes/Ember.Component');
+  assert.equal(currentURL(), '/ember/2.7/classes/Ember.Component', 'navigated to v2.7 namespace');
 
   await selectChoose('.select-container', '2.11');
-  assert.equal(currentURL(), '/ember/2.11/namespaces/Ember.String', 'navigated to v2.11 namespace');
+  assert.equal(currentURL(), '/ember/2.11/classes/Ember.Component', 'navigated to v2.11 namespace');
 
   await selectChoose('.select-container', '2.8');
-  assert.equal(currentURL(), '/ember/2.8/namespaces/Ember.String', 'navigated to v2.8 namespace');
+  assert.equal(currentURL(), '/ember/2.8/classes/Ember.Component', 'navigated to v2.8 namespace');
 
   // Modules
 

--- a/tests/integration/components/table-of-contents-test.js
+++ b/tests/integration/components/table-of-contents-test.js
@@ -1,4 +1,4 @@
-import { moduleForComponent, skip } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { findAll } from 'ember-native-dom-helpers';
 
@@ -6,7 +6,7 @@ moduleForComponent('table-of-contents', 'Integration | Component | table of cont
   integration: true
 });
 
-skip('it renders', function(assert) {
+test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   this.set('projectId', 'Ember');
   this.set('emberVersion', '2.4.3');
@@ -20,6 +20,7 @@ skip('it renders', function(assert) {
                                       projectid=projectId
                                       version=emberVersion
                                       classesIDs=classesIDs
+                                      isShowingNamespaces=true
                   }}`);
 
   assert.dom(findAll('.toc-level-0 > a')[2]).hasText('Classes');


### PR DESCRIPTION
Partially addresses #367

A bunch of tests were disabled for 2.16. I put them back and modified to get all but 1 passing again.

The one remaining skip is for version switching. Not sure what the final behavior ought to be.