### PR TITLE
redirect to method route when hash

### DIFF
--- a/app/controllers/class.js
+++ b/app/controllers/class.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['anchor', 'type']
+});

--- a/app/routes/project-version/classes/class.js
+++ b/app/routes/project-version/classes/class.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { set, get } from '@ember/object';
 import ScrollTracker from 'ember-api-docs/mixins/scroll-tracker';
 import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
 
 export default Route.extend(ScrollTracker, {
 
@@ -36,6 +37,14 @@ export default Route.extend(ScrollTracker, {
   },
 
   redirect(model, transition) {
+    if (transition.queryParams.anchor && transition.queryParams.type) {
+      let type = transition.queryParams.type;
+      this.transitionTo(`project-version.classes.class.${pluralize(type)}.${type}`,
+        transition.params['project-version'].project,
+        transition.params['project-version'].project_version,
+        transition.params['project-version.classes.class'].class,
+        transition.queryParams.anchor);
+    }
     if (model.isError) {
       this.transitionTo('404');
     }

--- a/lib/hash-to-query/index.js
+++ b/lib/hash-to-query/index.js
@@ -20,16 +20,12 @@ module.exports = {
         pathName.indexOf('/events/') === -1) {
       var type = hash.slice(1, hash.indexOf('_'));
       var name = hash.slice(hash.indexOf('_') + 1, hash.length);
-      var anchor = '?anchor=' + name + '&show=inherited,protected,private,deprecated';
-      var newPath = pathName;
-      if (type === 'method') {
-        newPath = pathName + '/methods/' + name;
-      } else if (type === 'property') {
-        newPath = pathName + '/properties/' + name;
-      } else if (type === 'event') {
-        newPath = pathName + '/events/' + name;
-      }
-      window.location.href = window.location.origin + newPath + anchor;
+      var anchor = '?anchor=' +
+                   name +
+                   '&show=inherited,protected,private,deprecated' +
+                   '&type=' +
+                   type;
+      window.location.href = window.location.origin + pathName + anchor;
     }
   }
 </script>


### PR DESCRIPTION
Part of the fix for #355 

fixes legacy urls with item hashes such as http://localhost:4200/classes/Ember.Component.html#method_didReceiveAttrs