### PR TITLE
Removed deprecation warnings for 'testSelector'

### DIFF
--- a/tests/acceptance/class-test.js
+++ b/tests/acceptance/class-test.js
@@ -1,15 +1,14 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import { test } from 'qunit';
 import { visit, click, findAll } from 'ember-native-dom-helpers';
-import testSelector from 'ember-test-selectors';
 
 moduleForAcceptance('Acceptance | Class', {
   async beforeEach() {
     await visit('/ember/1.0/classes/Container');
-    await click(testSelector('checkbox', 'inherited'));
-    await click(testSelector('checkbox', 'protected'));
-    await click(testSelector('checkbox', 'private'));
-    await click(testSelector('checkbox', 'deprecated'));
+    await click('[data-test-checkbox="inherited"]');
+    await click('[data-test-checkbox="protected"]');
+    await click('[data-test-checkbox="private"]');
+    await click('[data-test-checkbox="deprecated"]');
   }
 });
 
@@ -18,7 +17,7 @@ test('lists all the methods on the class page', async function (assert) {
   const container = store.peekRecord('class', 'ember-1.0.0-Container');
   assert.equal(findAll('.spec-method-list li').length, container.get('methods.length'));
 
-  await click(testSelector('checkbox', 'private')); // turn private back off
+  await click('[data-test-checkbox="private"]'); // turn private back off
 
   assert.equal(findAll('.spec-method-list li').length,
     container.get('methods').filter(method => method.access !== 'private').length);

--- a/tests/acceptance/items-test.js
+++ b/tests/acceptance/items-test.js
@@ -1,13 +1,12 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import { test } from 'qunit';
 import { visit, click, findAll} from 'ember-native-dom-helpers';
-import testSelector from 'ember-test-selectors';
 
 moduleForAcceptance('Acceptance | ItemRoutes');
 
 test('Can navigate to method from class', async function(assert) {
   await visit('/ember/1.0/classes/Container');
-  await click(`.spec-method-list ${testSelector('item', 'child')} a`);
+  await click(`.spec-method-list ${'[data-test-item="child"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/classes/Container/methods/child?anchor=child', 'navigated to method');
 });
@@ -22,28 +21,28 @@ test('Can navigate to method from method name', async function(assert) {
 
 test('Can navigate to property from class', async function(assert) {
   await visit('/ember/1.0/classes/Container');
-  await click(`.spec-property-list ${testSelector('item', 'cache')} a`);
+  await click(`.spec-property-list ${'[data-test-item="cache"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/classes/Container/properties/cache?anchor=cache', 'navigated to property');
 });
 
 test('Can navigate to method from namespace', async function(assert) {
   await visit('/ember/1.0/namespaces/Ember');
-  await click(`.spec-method-list ${testSelector('item', 'A')} a`);
+  await click(`.spec-method-list ${'[data-test-item="A"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/namespaces/Ember/methods/A?anchor=A', 'navigated to method');
 });
 
 test('Can navigate to property from namespace', async function(assert) {
   await visit('/ember/1.0/namespaces/Ember');
-  await click(`.spec-property-list ${testSelector('item', 'ENV')} a`);
+  await click(`.spec-property-list ${'[data-test-item="ENV"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/namespaces/Ember/properties/ENV?anchor=ENV', 'navigated to property');
 });
 
 test('Can navigate to event from namespace', async function(assert) {
   await visit('/ember/1.0/namespaces/Ember');
-  await click(`.spec-event-list ${testSelector('item', 'onerror')} a`);
+  await click(`.spec-event-list ${'[data-test-item="onerror"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/namespaces/Ember/events/onerror?anchor=onerror', 'navigated to event');
 });

--- a/tests/acceptance/method-inheritance-test.js
+++ b/tests/acceptance/method-inheritance-test.js
@@ -1,7 +1,6 @@
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 import { test } from 'qunit';
 import { visit, click, findWithAssert } from 'ember-native-dom-helpers';
-import testSelector from 'ember-test-selectors';
 
 moduleForAcceptance('Acceptance | method inheritance')
 
@@ -12,6 +11,6 @@ test('no duplicate methods displayed', async function (assert) {
 
 test('most local inherited method is shown', async function (assert) {
   await visit('/ember-data/2.14/classes/DS.JSONAPIAdapter');
-  await click(`${testSelector('item', 'createRecord')} a`)
+  await click(`${'[data-test-item="createRecord"]'} a`)
   assert.ok(findWithAssert("[data-test-file='addon/adapters/rest.js']"));
 });

--- a/tests/acceptance/sidebar-nav-test.js
+++ b/tests/acceptance/sidebar-nav-test.js
@@ -1,6 +1,5 @@
 import { test } from 'qunit';
 import { visit, click } from 'ember-native-dom-helpers';
-import testSelector from 'ember-test-selectors';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
@@ -8,21 +7,21 @@ moduleForAcceptance('Acceptance | sidebar navigation');
 
 test('can navigate to namespace from sidebar', async function(assert) {
   await visit('/ember/1.0');
-  await click(`${testSelector('namespace', 'Ember.String')} a`);
+  await click(`${'[data-test-namespace="Ember.String"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/namespaces/Ember.String', 'navigated to namespace');
 });
 
 test('can navigate to module from sidebar', async function(assert) {
   await visit('/ember/1.0');
-  await click(`${testSelector('module', 'ember-application')} a`);
+  await click(`${'[data-test-module="ember-application"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/modules/ember-application', 'navigated to module');
 });
 
 test('can navigate to class from sidebar', async function(assert) {
   await visit('/ember/1.0');
-  await click(`${testSelector('class', 'Ember.Component')} a`);
+  await click(`${'[data-test-class="Ember.Component"]'} a`);
 
   assert.equal(currentURL(), '/ember/1.0/classes/Ember.Component', 'navigated to class');
 });

--- a/tests/acceptance/tab-nav-test.js
+++ b/tests/acceptance/tab-nav-test.js
@@ -1,7 +1,6 @@
 import { test } from 'qunit';
 import { visit, click } from 'ember-native-dom-helpers';
 import $ from 'jquery';
-import testSelector from 'ember-test-selectors';
 
 import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
 
@@ -13,24 +12,24 @@ moduleForAcceptance('Acceptance | tab navigation');
 
 test('switching tabs', async function(assert) {
   await visit('/ember/1.0/classes/Ember.Component');
-  await click(testSelector('checkbox', 'inherited'));
-  await click(`.tabbed-layout__menu ${testSelector('tab', 'methods')}`);
+  await click('[data-test-checkbox="inherited"]');
+  await click(`.tabbed-layout__menu ${'[data-test-tab="methods"]'}`);
 
   assert.equal(currentURLNoParams(), '/ember/1.0/classes/Ember.Component/methods', 'navigated to methods');
-  assert.ok($(`.tabbed-layout__menu ${testSelector('tab', 'methods')}`).hasClass('tabbed-layout__menu__item_selected'), 'methods tab selected');
+  assert.ok($(`.tabbed-layout__menu ${'[data-test-tab="methods"]'}`).hasClass('tabbed-layout__menu__item_selected'), 'methods tab selected');
 
-  await click(`.tabbed-layout__menu ${testSelector('tab', 'properties')}`);
+  await click(`.tabbed-layout__menu ${'[data-test-tab="properties"]'}`);
 
   assert.equal(currentURLNoParams(), '/ember/1.0/classes/Ember.Component/properties', 'navigated to properties');
-  assert.ok($(`.tabbed-layout__menu ${testSelector('tab', 'properties')}`).hasClass('tabbed-layout__menu__item_selected'), 'properties tab selected');
+  assert.ok($(`.tabbed-layout__menu ${'[data-test-tab="properties"]'}`).hasClass('tabbed-layout__menu__item_selected'), 'properties tab selected');
 
-  await click(`.tabbed-layout__menu ${testSelector('tab', 'events')}`);
+  await click(`.tabbed-layout__menu ${'[data-test-tab="events"]'}`);
 
   assert.equal(currentURLNoParams(), '/ember/1.0/classes/Ember.Component/events', 'navigated to events');
-  assert.ok($(`.tabbed-layout__menu ${testSelector('tab', 'events')}`).hasClass('tabbed-layout__menu__item_selected'), 'events tab selected');
+  assert.ok($(`.tabbed-layout__menu ${'[data-test-tab="events"]'}`).hasClass('tabbed-layout__menu__item_selected'), 'events tab selected');
 
-  await click(`.tabbed-layout__menu ${testSelector('tab', 'index')}`);
+  await click(`.tabbed-layout__menu ${'[data-test-tab="index"]'}`);
 
   assert.equal(currentURLNoParams(), '/ember/1.0/classes/Ember.Component', 'navigated to index');
-  assert.ok($(`.tabbed-layout__menu ${testSelector('tab', 'index')}`).hasClass('tabbed-layout__menu__item_selected'), 'index tab selected');
+  assert.ok($(`.tabbed-layout__menu ${'[data-test-tab="index"]'}`).hasClass('tabbed-layout__menu__item_selected'), 'index tab selected');
 });


### PR DESCRIPTION
Deprecations like this

```js
        { type: 'warn',
              text: '\'DEPRECATION: Using the "testSelector" helper function is deprecated as it obfuscates the selectors, making the tests harder to understand.\\nPlease use the actual attribute selectors instead, e.g. "[data-test-my-element]" instead of "testSelector(\\\'my-element\\\')". [deprecation id: ember-test-selectors.test-selector-helper] See https://github.com/simplabs/ember-test-selectors#usage for more details.\\n        at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:24829:21)\\n        at HANDLERS.(anonymous function) (http://localhost:7357/assets/vendor.js:25041:9)\\n        at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:24859:14)\\n        at HANDLERS.(anonymous function) (http://localhost:7357/assets/vendor.js:25041:9)\\n        at invoke (http://localhost:7357/assets/vendor.js:25053:9)\\n        at deprecate (http://localhost:7357/assets/vendor.js:24913:24)\\n        at testSelector (http://localhost:7357/assets/vendor.js:99896:5)\\n        at Object._callee$ (http://localhost:7357/assets/tests.js:201:90)\\n        at tryCatch (http://localhost:7357/assets/vendor.js:404:40)\'\n' }
```

removed by https://github.com/lorcan/test-selectors-codemod