### PR TITLE
show private functions when toggled

### DIFF
--- a/app/controllers/project-version/modules/module.js
+++ b/app/controllers/project-version/modules/module.js
@@ -27,11 +27,20 @@ export default ClassController.extend({
     return uniq(union(this.get('namespaces'), this.get('classes')).sort(), true);
   }),
 
-  functionHeadings: computed('model', function () {
-    if (this.get('model.staticfunctions')) {
+  functionHeadings: computed('model', 'showPrivateClasses', function () {
+    if (this.get('model.allstaticfunctions') && this.get('showPrivateClasses')) {
+      return Object.keys(this.get('model.allstaticfunctions')).sort();
+    } else if (this.get('model.staticfunctions')) {
       return Object.keys(this.get('model.staticfunctions')).sort();
     }
     return {};
+  }),
+
+  functions: computed('model', 'showPrivateClasses', function () {
+    if (this.get('showPrivateClasses') && this.get('model.allstaticfunctions')) {
+      return this.get('model.allstaticfunctions');
+    }
+    return this.get('model.staticfunctions');
   })
 
 });

--- a/app/models/module.js
+++ b/app/models/module.js
@@ -10,5 +10,6 @@ export default ClassModel.extend({
   namespaces: attr(),
   parent: attr(),
   staticfunctions: attr(),
+  allstaticfunctions: attr(),
   projectVersion: belongsTo('project-version', {inverse: 'modules'})
 });

--- a/app/templates/project-version/modules/module.hbs
+++ b/app/templates/project-version/modules/module.hbs
@@ -49,7 +49,7 @@
     {{#each functionHeadings as |funcHeading|}}
       <h4>{{funcHeading}}</h4>
       <ul class="spec-method-list">
-        {{#each (better-get model.staticfunctions funcHeading) as |method|}}
+        {{#each (better-get functions funcHeading) as |method|}}
           <li>
             {{#link-to 'project-version.classes.class.methods.method'
                model.project.id


### PR DESCRIPTION
goes along with https://github.com/ember-learn/ember-jsonapi-docs/pull/47 to show private functions in packages when "show private classes" is toggled.