### PR TITLE
Simplify duplicate filtering

### DIFF
--- a/app/components/api-index-filter.js
+++ b/app/components/api-index-filter.js
@@ -1,6 +1,5 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
-import uniq from 'npm:lodash.uniq';
 import sortBy from 'npm:lodash.sortby';
 
 const filterDataComputedParams = 'filterData.{showInherited,showProtected,showPrivate,showDeprecated}';
@@ -38,8 +37,8 @@ export default Component.extend({
       items = items.filter(item => item.deprecated !== true);
     }
 
-    let sortedUniqueItems = uniq(sortBy(items, 'name'), true, (item => item.name));
-    return this.filterMultipleInheritance(sortedUniqueItems);
+    let sortedItems = sortBy(items, (item => item.name));
+    return this.filterMultipleInheritance(sortedItems);
   },
 
   filteredData: computed('filteredMethods', 'filteredProperties', 'filteredEvents', function() {

--- a/tests/integration/components/api-index-filter-test.js
+++ b/tests/integration/components/api-index-filter-test.js
@@ -15,10 +15,20 @@ const model = EmberObject.create({
     version: '2.9'
   },
   name: 'hai',
+  file: 'my-class',
+  parentClass: {
+    file: 'my-class'
+  },
   methods: [
     {
       name: 'doSomething',
-      route: 'do-something'
+      route: 'do-something',
+      file: 'my-class'
+    },
+    {
+      name: 'doSomething',
+      route: 'do-something',
+      file: 'my-parent-class'
     },
     {
       name: 'parentDoSomething',
@@ -369,5 +379,31 @@ test('clicking all toggles off should only show public', async function(assert) 
 
   assert.dom('.method-name').exists({ count: 1 }, 'should display all methods');
   assert.dom(findAll('.method-name')[0]).hasText('doSomething', 'should display 1 public method');
+
+});
+
+
+test('should show only local method implementation when duplicates', async function (assert) {
+  let filterData = EmberObject.create({
+    showInherited: true,
+    showProtected: false,
+    showPrivate: false,
+    showDeprecated: false
+  });
+
+  this.set('model', model);
+  this.set('filterData', filterData);
+
+  this.render(hbs`
+    {{#api-index-filter model=model filterData=filterData as |myModel|}}
+        <h2>Methods</h2>
+        {{#each myModel.methods as |method|}}
+          <p class=\"method-name\">{{method.name}}</p>
+        {{/each}}
+    {{/api-index-filter}}
+  `);
+  assert.equal(findAll('.method-name').length, 2, 'should display only the local method and the parent method with a different name');
+  assert.dom(findAll('.method-name')[0]).hasText('doSomething', 'should display 1 public method');
+  assert.dom(findAll('.method-name')[1]).hasText('parentDoSomething', 'should display 1 inherited method');
 
 });


### PR DESCRIPTION
Addresses https://github.com/ember-learn/ember-api-docs/issues/375

- uses lodash according to documentation.  
- Removed an unnecessary uniq call
- adds a duplicates test case