### PR TITLE
add link rel canonical for release url

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -11,14 +11,15 @@ export default Route.extend({
     const [version, entity] = tokens;
     if (version) {
       const compactVersion = getCompactVersion(version);
-
       const title = `${[entity, compactVersion].join(' - ')} - Ember API Documentation`;
-
       set(this, 'headData.title', title);
-      set(this, 'headData.cdnDomain', ENV.API_HOST);
       return title;
     }
     return '';
+  },
+  afterModel(resolvedModel, transition) {
+    set(this, 'headData.cdnDomain', ENV.API_HOST);
+    return this._super(...arguments);
   }
 
 });

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -5,9 +5,9 @@ import getCompactVersion from 'ember-api-docs/utils/get-compact-version';
 import getFullVersion from 'ember-api-docs/utils/get-full-version';
 
 export default Route.extend({
-
+  fastboot: service(),
+  headData: service(),
   metaStore: service(),
-
   projectService: service('project'),
 
   titleToken: function(model) {
@@ -24,6 +24,7 @@ export default Route.extend({
 
   // Using redirect instead of afterModel so transition succeeds and returns 30
   redirect(model, transition) {
+    this._gatherHeadDataFromVersion(model, transition.params['project-version'].project_version);
     let classParams = transition.params['project-version.classes.class'];
     let moduleParams = transition.params['project-version.modules.module'];
     let namespaceParams = transition.params['project-version.namespaces.namespace'];
@@ -31,6 +32,17 @@ export default Route.extend({
       let moduleRevs = this.get('metaStore').getEncodedModulesFromProjectRev(model.get('id'));
       let module = this.getFirstModule(moduleRevs);
       return this.transitionTo('project-version.modules.module', model.get('project.id'), model.get('compactVersion'), module);
+    }
+  },
+
+  _gatherHeadDataFromVersion(model, projectVersion) {
+    this.set('headData.isRelease', projectVersion === 'release');
+    this.set('headData.compactVersion', model.get('compactVersion'));
+    this.set('headData.urlVersion', projectVersion);
+    if (this.get('headData.isRelease')) {
+      let request = this.get('fastboot.request');
+      let href = this.get('fastboot.isFastBoot') ? `${request.protocol}//${request.host}${request.path}` : window.location.href;
+      this.set('headData.canonicalUrl', href.replace(/release/, model.get('compactVersion')));
     }
   },
 

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,7 +1,6 @@
 <title>{{model.title}}</title>
 
-<link rel="dns-prefetch" href="{{cdnDomain}}" >
-
+<link rel="dns-prefetch" href="{{model.cdnDomain}}" >
 <meta property="og:title" content={{model.title}} >
 <meta property="og:image" content="assets/images/ember-logo.png" >
 <meta property="og:image:width" content="1200" >
@@ -9,4 +8,7 @@
 
 {{#if model.description}}
   <meta property="og:description" content={{model.description}} >
+{{/if}}
+{{#if model.isRelease}}
+  <link rel="canonical" href={{model.canonicalUrl}}>
 {{/if}}

--- a/tests/acceptance/head-test.js
+++ b/tests/acceptance/head-test.js
@@ -1,0 +1,31 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
+import { visit } from 'ember-native-dom-helpers';
+import $ from 'jquery';
+
+moduleForAcceptance('Acceptance | head');
+
+test('shows link rel=canonical for release url', async function (assert) {
+  await visit('/ember/release/classes/Application');
+  assert.ok($('head link[rel=canonical]').attr('href'));
+});
+
+test('no link rel=canonical for version url', async function (assert) {
+  await visit('/ember/2.16/classes/Application');
+  assert.notOk($('head link[rel=canonical]').attr('href'));
+});
+
+test('no link rel=canonical when root url visited', async function (assert) {
+  await visit('/');
+  assert.notOk($('head link[rel=canonical]').attr('href'));
+})
+
+test('dns prefetch should be populated', async function (assert) {
+  await visit('/ember/release/classes/Application');
+  assert.equal($('head link[rel=dns-prefetch]').attr('href'), 'https://ember-api-docs.global.ssl.fastly.net');
+});
+
+test('dns prefetch should be populated when root url visited', async function (assert) {
+  await visit('/');
+  assert.equal($('head link[rel=dns-prefetch]').attr('href'), 'https://ember-api-docs.global.ssl.fastly.net');
+})


### PR DESCRIPTION
Initial pass at adding link canonical tag to api docs in support of `release` url
Part of addressing #407