### PR TITLE
When release in url, make toc links release too (for highlight)

### DIFF
--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import values from 'npm:lodash.values';
@@ -13,6 +14,8 @@ export default Controller.extend(FilterParams, {
   filterData: service(),
 
   metaStore: service(),
+
+  project: service(),
 
   showPrivateClasses: computed.alias('filterData.sideNav.showPrivate'),
 
@@ -82,6 +85,8 @@ export default Controller.extend(FilterParams, {
 
     return values(groupedVersions).map(groupedVersion => groupedVersion[0]);
   }),
+
+  urlVersion: alias('project.urlVersion'),
 
   selectedProjectVersion:computed('projectVersions.[]', 'model.version', function() {
     return this.get('projectVersions').filter(pV => pV.id === this.get('model.version'))[0];

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -18,6 +18,7 @@ export default Route.extend({
     let projectObj = await this.store.findRecord('project', project);
     let projectVersion = getFullVersion(project_version, project, projectObj, this.get('metaStore'));
     let id = `${project}-${projectVersion}`;
+    this.get('projectService').setUrlVersion(project_version);
     this.get('projectService').setVersion(projectVersion);
     return this.store.findRecord('project-version', id, { includes: 'project' });
   },

--- a/app/services/project.js
+++ b/app/services/project.js
@@ -13,5 +13,13 @@ export default Service.extend({
 
   setVersion(version) {
     this.set('version', version);
+  },
+
+  setUrlVersion(version) {
+    this.set('urlVersion', version);
+  },
+
+  getUrlVersion() {
+    return this.get('urlVersion');
   }
 });

--- a/app/templates/project-version.hbs
+++ b/app/templates/project-version.hbs
@@ -25,7 +25,7 @@
 
   {{table-of-contents
     projectId=model.project.id
-    version=model.compactVersion
+    version=urlVersion
     classesIDs=shownClassesIDs
     moduleIDs=shownModuleIDs
     namespaceIDs=shownNamespaceIDs

--- a/tests/unit/controllers/project-version-test.js
+++ b/tests/unit/controllers/project-version-test.js
@@ -29,7 +29,7 @@ const expectedModuleNames = [
 ];
 
 moduleFor('controller:project-version', 'Unit | Controller | project version', {
-  needs: ['service:filterData', 'service:metaStore', 'service:analytics']
+  needs: ['service:filterData', 'service:metaStore', 'service:analytics', 'service:project']
 });
 
 test('should render module names', function(assert) {


### PR DESCRIPTION
part of fix for #407 
Should've made it into #409 but I guess I was sleepy when doing this :-P

essentially the code here makes it so that when you load a url with `release` as the version, then all the table of contents (left nav) urls will also have `release` in it.  

Side affect is that the currently shown item in the left nav becomes "active" (from link-to bc it matches the current url) meaning the css knows to highlight it.