### PR TITLE
refer to config'd host instead of relative url

### DIFF
--- a/app/services/legacy-module-mappings.js
+++ b/app/services/legacy-module-mappings.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import fetch from 'fetch';
 import { task } from 'ember-concurrency';
+import ENV from 'ember-api-docs/config/environment';
 
 export default Ember.Service.extend({
 
@@ -9,9 +10,13 @@ export default Ember.Service.extend({
   },
 
   initMappings: task(function * () {
-    let response = yield fetch('/assets/mappings.json');
-    let mappings = yield response.json();
-    this.set('mappings', mappings);
+    try {
+      let response = yield fetch(`${ENV.API_HOST}/assets/mappings.json`);
+      let mappings = yield response.json();
+      this.set('mappings', mappings);
+    } catch (e) {
+      this.set('mappings', []);
+    }
   }),
 
   hasFunctionMapping(name, module) {

--- a/app/services/legacy-module-mappings.js
+++ b/app/services/legacy-module-mappings.js
@@ -11,7 +11,7 @@ export default Ember.Service.extend({
 
   initMappings: task(function * () {
     try {
-      let response = yield fetch(`${ENV.API_HOST}/assets/mappings.json`);
+      let response = yield fetch(`${ENV.routerRootURL}assets/mappings.json`);
       let mappings = yield response.json();
       this.set('mappings', mappings);
     } catch (e) {


### PR DESCRIPTION
when we initially deployed to prod the code below wasn't fetching the mappings file bc fastly didn't have it.  When it failed we were getting errors.

Therefore, doing 2 things:

* ~~fetching based on the resolved host (instead of relative)~~
* fetch using the routerRootURL (which knows when to add `/api/`)
* on error setting mappings empty, which will just result in the import examples not showing up and let the user proceed, just with out import examples, which is much more graceful.
  