### PR TITLE
encode module name when switching versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js:
 - '8'
 
 dist: trusty
-sudo: false
+sudo: required
+group: deprecated-2017Q4
 
 addons:
   chrome: stable

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -70,7 +70,7 @@ export default Route.extend({
           break;
         }
         case 'project-version.modules.module.index': {
-          let moduleName = this.paramsFor('project-version.modules.module').module;
+          let moduleName = encodeURIComponent(this.paramsFor('project-version.modules.module').module);
           endingRoute = `modules/${moduleName}`;
           break;
         }

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -32,6 +32,16 @@ test('switching module versions less than 2.16 should retain module page', async
   assert.equal(currentURL(), '/ember/1.4/modules/ember-metal', 'navigated to v2.7 module');
 });
 
+
+test('switching module versions greater than 2.16 should retain module page', async function(assert) {
+  await visit('/ember/2.18/modules/@ember%2Fapplication');
+  assert.equal(currentURL(), '/ember/2.18/modules/@ember%2Fapplication', 'navigated to v2.18 module');
+  await selectChoose('.select-container', '2.17');
+  assert.equal(currentURL(), '/ember/2.17/modules/@ember%2Fapplication', 'navigated to v2.17 module');
+  await selectChoose('.select-container', '2.16');
+  assert.equal(currentURL(), '/ember/2.16/modules/@ember%2Fapplication', 'navigated to v2.16 module');
+});
+
 test('switching specific method less than 2.16 should retain method', async function (assert) {
   await visit('/ember/2.8/classes/Ember.Component/methods/didReceiveAttrs?anchor=didReceiveAttrs')
   assert.equal(currentURL(), '/ember/2.8/classes/Ember.Component/methods/didReceiveAttrs?anchor=didReceiveAttrs', 'navigated to v2.8 method');
@@ -87,6 +97,3 @@ test('switching from class version 2.16 to class version less then 2.16 should r
   await selectChoose('.select-container', '2.11');
   assert.equal(currentURL(), '/ember/2.11/modules/ember', 'navigated to v2.11 ember module');
 });
-
-
-


### PR DESCRIPTION
Addresses #417 

Problem was that the module name we would fetch was unencoded, so the url ended up being `@ember/application` as opposed to `@ember%2Fapplication`

A simple call to `encodeURIComponent` does the trick.