### PR TITLE
[Dont-Merge] initial naive implementation of prember as a POC

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,8 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const Funnel = require('broccoli-funnel');
 const mergeTrees  = require('broccoli-merge-trees');
+const fetch = require('node-fetch')
+const _ = require('lodash');
 
 module.exports = function(defaults) {
   let prepend = '';
@@ -12,6 +14,23 @@ module.exports = function(defaults) {
   }
 
   let app = new EmberApp(defaults, {
+    prember: {
+      urls() {
+        return fetch('https://ember-api-docs.global.ssl.fastly.net/rev-index/ember-2.18.0.json')
+          .then(res => res.json())
+          .then(json => {
+            return _.chain(json)
+              .get('data.relationships.classes.data')
+              .map('id')
+              .map(id => {
+                const parts = id.split('-');
+
+                return `${parts[0]}/${parts[1]}/classes/${parts[2]}`;
+              })
+              .value();
+          });
+      }
+    },
     fingerprint: {
       extensions: ['js', 'css', 'jpg', 'png', 'gif', 'map', 'svg', 'webmanifest'],
       prepend,

--- a/package.json
+++ b/package.json
@@ -84,8 +84,11 @@
     "ember-web-app": "^2.0.0",
     "fastboot-app-server": "^1.0.1",
     "loader.js": "^4.6.0",
+    "lodash": "^4.17.5",
     "minimist": "^1.2.0",
+    "node-fetch": "^2.0.0",
     "normalize.css": "^7.0.0",
+    "prember": "^0.2.2",
     "qunit-dom": "^0.3.2"
   },
   "engines": {


### PR DESCRIPTION
Howdy folks 👋 

I started a conversation with bupkizz on the ember community slack about SEO and I didn't know that the fastboot situation was giving you grief. I mentioned that we have had a very successful time of using prember on the new deprecations-app and the new guides-app so I thought I'd start the conversation over here.

You can pull this branch and run `ember build -e production` to see the prember in action, and then have a look at the dist folder to see the results.

<img width="546" alt="screen shot 2018-02-08 at 20 54 00" src="https://user-images.githubusercontent.com/594890/35998108-934144d2-0d13-11e8-950b-632cbd3675b7.png">

![screen shot 2018-02-08 at 20 54 51](https://user-images.githubusercontent.com/594890/35998123-9d7b1414-0d13-11e8-809d-85b763875dca.png)

now, this could cause some issues with trailing slashes but I have a way to fix that too 😂 I thought this was at least enough to get the conversation started anyway.
