### PR TITLE
convert object, array, and ember to ember names

### DIFF
--- a/app/components/import-example.js
+++ b/app/components/import-example.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { run: { later }, Component } = Ember;
+import Component from '@ember/component';
+import { later } from '@ember/runloop';
 
 export default Component.extend({
   actions: {

--- a/app/services/legacy-module-mappings.js
+++ b/app/services/legacy-module-mappings.js
@@ -3,6 +3,12 @@ import fetch from 'fetch';
 import { task } from 'ember-concurrency';
 import config from 'ember-api-docs/config/environment';
 
+const LOCALNAME_CONVERSIONS = {
+  Object: 'EmberObject',
+  Array: 'EmberArray',
+  Error: 'EmberError'
+};
+
 export default Ember.Service.extend({
 
   init() {
@@ -13,7 +19,14 @@ export default Ember.Service.extend({
     try {
       let response = yield fetch(`${config.APP.cdnUrl}/assets/mappings.json`);
       let mappings = yield response.json();
-      this.set('mappings', mappings);
+      let newMappings = mappings.map(item => {
+        let newItem = Object.assign({}, item);
+        if (LOCALNAME_CONVERSIONS[newItem.localName]) {
+          newItem.localName = LOCALNAME_CONVERSIONS[newItem.localName];
+        }
+        return newItem;
+      });
+      this.set('mappings', newMappings);
     } catch (e) {
       this.set('mappings', []);
     }


### PR DESCRIPTION
Ticks of 3 of the items from #423 EmberArray, EmberObject, and EmberError

Since it may take a while to get consensus around https://github.com/ember-cli/ember-rfc176-data/issues/42 I'd like to just convert these client side for inline examples.