### PR TITLE
Makes import syntax CP’s just regular props. Fixes old package import syntax. Updates title to handle no entity in tokens.

### DIFF
--- a/app/controllers/project-version/index.js
+++ b/app/controllers/project-version/index.js
@@ -3,11 +3,7 @@ import Ember from 'ember';
 const { computed } = Ember;
 
 export default Controller.extend({
-  oldPackageImportSyntax: computed(function() {
-    return Ember.String.htmlSafe("<div class='highlight javascript'> <div class='ribbon'></div><div class='scroller'> <table class='CodeRay'> <tbody> <tr> <td class='line-numbers'> <pre>1\n2\n3\n4</pre></td><td class='code'><pre><span class='keyword'>import</span> Ember <span class='keyword'>from</span> <span class='string'>'ember'</span>;\n<span class='keyword'>export</span> <span class='keyword'>default</span> Component.extend({<span class='comment'>\n  // this is the old way</span>\n});</pre> </td></tr></tbody> </table> </div></div>")
-  }),
+  oldPackageImportSyntax: Ember.String.htmlSafe("<div class='highlight javascript'> <div class='ribbon'></div><div class='scroller'> <table class='CodeRay'> <tbody> <tr> <td class='line-numbers'> <pre>1\n2\n3\n4</pre></td><td class='code'><pre><span class='keyword'>import</span> Ember <span class='keyword'>from</span> <span class='string'>'ember'</span>;\n<span class='keyword'>export</span> <span class='keyword'>default</span> Ember.Component.extend({<span class='comment'>\n  // this is the old way</span>\n});</pre> </td></tr></tbody> </table> </div></div>"),
 
-  newPackageImportSyntax: computed(function() {
-    return Ember.String.htmlSafe("<div class='highlight javascript'> <div class='ribbon'></div><div class='scroller'> <table class='CodeRay'> <tbody> <tr> <td class='line-numbers'><pre>1\n2\n3\n4</pre> </td><td class='code'><pre><span class='keyword'>import</span> Component <span class='keyword'>from</span> <span class='string'>'@ember/component'</span>;\n<span class='keyword'>export</span> <span class='keyword'>default</span> Component.extend({<span class='comment'>\n  // this is the current way</span>\n});</pre> </td></tr></tbody> </table> </div></div>")
-  })
+  newPackageImportSyntax: Ember.String.htmlSafe("<div class='highlight javascript'> <div class='ribbon'></div><div class='scroller'> <table class='CodeRay'> <tbody> <tr> <td class='line-numbers'><pre>1\n2\n3\n4</pre> </td><td class='code'><pre><span class='keyword'>import</span> Component <span class='keyword'>from</span> <span class='string'>'@ember/component'</span>;\n<span class='keyword'>export</span> <span class='keyword'>default</span> Component.extend({<span class='comment'>\n  // this is the current way</span>\n});</pre> </td></tr></tbody> </table> </div></div>")
 });

--- a/app/controllers/project-version/index.js
+++ b/app/controllers/project-version/index.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
 import Ember from 'ember';
-const { computed } = Ember;
 
 export default Controller.extend({
   oldPackageImportSyntax: Ember.String.htmlSafe("<div class='highlight javascript'> <div class='ribbon'></div><div class='scroller'> <table class='CodeRay'> <tbody> <tr> <td class='line-numbers'> <pre>1\n2\n3\n4</pre></td><td class='code'><pre><span class='keyword'>import</span> Ember <span class='keyword'>from</span> <span class='string'>'ember'</span>;\n<span class='keyword'>export</span> <span class='keyword'>default</span> Ember.Component.extend({<span class='comment'>\n  // this is the old way</span>\n});</pre> </td></tr></tbody> </table> </div></div>"),

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -8,7 +8,8 @@ export default Route.extend({
   headData: service(),
 
   title(tokens) {
-    const [version, entity] = tokens;
+    let [version, entity] = tokens;
+    if (!entity) entity = 'Ember';
     if (version) {
       const compactVersion = getCompactVersion(version);
       const title = `${[entity, compactVersion].join(' - ')} - Ember API Documentation`;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -9,7 +9,9 @@ export default Route.extend({
 
   title(tokens) {
     let [version, entity] = tokens;
-    if (!entity) entity = 'Ember';
+    if (!entity) {
+      entity = 'Ember';
+    }
     if (version) {
       const compactVersion = getCompactVersion(version);
       const title = `${[entity, compactVersion].join(' - ')} - Ember API Documentation`;


### PR DESCRIPTION
Addresses some of the outstanding review comments in #454.