### PR TITLE
Revert "Fix broken function links for rsvp and jquery"

### DIFF
--- a/app/routes/project-version/functions/function.js
+++ b/app/routes/project-version/functions/function.js
@@ -18,21 +18,12 @@ export default Route.extend({
     let projectObj = await this.store.findRecord('project', projectID);
     let compactVersion = transition.params['project-version'].project_version;
     let projectVersion = getFullVersion(compactVersion, projectID, projectObj, this.get('metaStore'));
-    let name = params['module'];
+    let className = params['module'];
     let functionName = params['fn'];
-    let fnModule;
-    let fn;
-    if (name === 'rsvp' || name === 'jquery') {
-      fnModule = await this.store.find('module', `${projectID}-${projectVersion}-${name}`);
-      fn = fnModule.get(`allstaticfunctions.${name}`).find(elem => elem.name === functionName);
-
-    } else {
-      fnModule = await this.store.find('class', `${projectID}-${projectVersion}-${name}`);
-      fn = this.getFunctionObjFromList(fnModule, functionName);
-    }
+    let classObj = await this.store.find('class', `${projectID}-${projectVersion}-${className}`)
     return {
-      fnModule,
-      fn
+      fnModule: classObj,
+      fn: this.getFunctionObjFromList(classObj, functionName)
     };
   },
 


### PR DESCRIPTION
This reverts commit ccf6776bab9015e3134886a8ef1e1a2475c4a3e3.

In this fix the markdown code examples were not being converted to html.  Will need to find a better solution.