### PR TITLE
Fix timeout on invalid legacy urls

### DIFF
--- a/app/routes/class.js
+++ b/app/routes/class.js
@@ -8,8 +8,6 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
       .then((project) => {
-        //let versions = project.get('projectVersions').toArray();
-        //let lastVersion = getLastVersion(versions);
         // Currently redirecting to last 2.15 version until we can map old
         // Ember.* apis with rfc 176 items
         let lastVersion = '2.15.3';
@@ -40,17 +38,15 @@ export default Route.extend({
                 };
               });
             })
-            .catch((e) => {
-              return this.transitionTo('project-version');
-            })
         });
 
-      }).catch((e) => {
-        return this.transitionTo('project-version');
-      });
+      }).catch(e => resolve({ isError: true}));
   },
 
   redirect(model) {
+    if (model.isError) {
+      return this.transitionTo('404');
+    }
     let compactVersion = getCompactVersion(model.version);
     return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
       model.project.id,

--- a/app/routes/data-class.js
+++ b/app/routes/data-class.js
@@ -1,6 +1,5 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
@@ -8,8 +7,6 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
       .then((project) => {
-        // let versions = project.get('projectVersions').toArray();
-        // let lastVersion = getLastVersion(versions);
         let lastVersion = '2.15.3';
         return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
       })
@@ -36,14 +33,14 @@ export default Route.extend({
                 };
               });
             })
-            .catch((e) => {
-              return this.transitionTo('project-version');
-            })
-        });
+        }).catch(e => resolve({isError: true}));
       });
   },
 
   redirect(model) {
+    if (model.isError) {
+      return this.transitionTo('404');
+    }
     return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
       model.project.id,
       model.version,

--- a/app/routes/data-module.js
+++ b/app/routes/data-module.js
@@ -1,6 +1,5 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
@@ -8,8 +7,6 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
       .then((project) => {
-        // let versions = project.get('projectVersions').toArray();
-        // let lastVersion = getLastVersion(versions);
         let lastVersion = '2.15.3';
         return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
       })
@@ -28,17 +25,14 @@ export default Route.extend({
                 data: classData
               };
             })
-            .catch((e) => {
-              return this.transitionTo('project-version');
-            })
-        });
-
-      }).catch((e) => {
-        return this.transitionTo('project-version');
-      });
+        }).catch(e => resolve({isError: true}));
+      }).catch(e => resolve({isError: true}));
   },
 
   redirect(model) {
+    if (model.isError) {
+      return this.transitionTo('404');
+    }
     return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
       model.project.id,
       model.version,

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -1,6 +1,5 @@
 import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-//import getLastVersion from 'ember-api-docs/utils/get-last-version';
 
 import { pluralize } from 'ember-inflector';
 
@@ -9,8 +8,6 @@ export default Route.extend({
   model(params) {
     return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
       .then(project => {
-        // let versions = project.get('projectVersions').toArray();
-        // let lastVersion = getLastVersion(versions);
         let lastVersion = '2.15.3';
         return this.get('store').findRecord('project-version', `ember-${lastVersion}`, { includes: 'project' });
       })
@@ -27,18 +24,14 @@ export default Route.extend({
             .then(classData => {
               return { type: 'module', data: classData };
             })
-            .catch((e) => {
-              return this.transitionTo('project-version');
-            })
-
-        });
-
-      }).catch((e) => {
-        return this.transitionTo('project-version');
-      });
+        }).catch(e => resolve({isError:true}));
+      }).catch(e => resolve({isError:true}));
   },
 
   redirect(model) {
+    if (model.isError) {
+      return this.transitionTo('404');
+    }
     return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
       model.project.id,
       model.version,


### PR DESCRIPTION
Fixes the timeouts we were seeing on legacy url redirects.  When a legacy url points to class that no longer exists as of 2.15, we are getting timeouts.  This is because of a fastboot quirk we've seen before (see ember-fastboot/ember-cli-fastboot#202 and #186) where we have to do transitions in the redirect hook.  This should clear up some of our heroku timeout and maybe some of the memory issues.