### PR TITLE
Fix issue with fastboot canonical URL for API docs

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -56,9 +56,9 @@ export default Route.extend({
     this.set('headData.urlVersion', projectVersion);
     if (!this.get('headData.isRelease')) {
       let request = this.get('fastboot.request');
-      let href = this.get('fastboot.isFastBoot') ? `${request.protocol}//${request.host}${request.path}` : window.location.href;
+      let href = this.get('fastboot.isFastBoot') ? `${request.protocol}//${request.get('host')}${request.path}` : window.location.href;
       let version = new RegExp(model.get('compactVersion'), 'g')
-      let canonicalUrl =href.replace(version, 'release');
+      let canonicalUrl = href.replace(version, 'release');
       this.set('headData.canonicalUrl', canonicalUrl);
     }
   },


### PR DESCRIPTION
Fix issue #491. The way we infer the canonical URL for fastboot seems to be inaccurate. The issue exists in prod and I was able to verify it locally too.
