### PR TITLE
Hardcode canonical URL to emberjs.com/api

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -56,7 +56,7 @@ export default Route.extend({
     this.set('headData.urlVersion', projectVersion);
     if (!this.get('headData.isRelease')) {
       let request = this.get('fastboot.request');
-      let href = this.get('fastboot.isFastBoot') ? `${request.protocol}//${request.get('host')}${request.path}` : window.location.href;
+      let href = this.get('fastboot.isFastBoot') ? `${request.protocol}//emberjs.com/api${request.path}` : window.location.href;
       let version = new RegExp(model.get('compactVersion'), 'g')
       let canonicalUrl = href.replace(version, 'release');
       this.set('headData.canonicalUrl', canonicalUrl);


### PR DESCRIPTION
By default fastboot will use the machine host rather than the request's host

Hardcoding ensures we will always canonical to emberjs.com/api

![canonical](https://user-images.githubusercontent.com/1851748/38829816-e3dcb598-417f-11e8-9526-66133561081c.png)

Should resolve the remaining open issue for https://github.com/ember-learn/ember-api-docs/issues/491