### PR TITLE
wip: convert legacy urls to "release" route instead of 2.15

### DIFF
--- a/app/routes/class.js
+++ b/app/routes/class.js
@@ -1,63 +1,31 @@
-import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import getCompactVersion from 'ember-api-docs/utils/get-compact-version';
-import { pluralize } from 'ember-inflector';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
 
+  legacyModuleMappings: service(),
+
   model(params) {
-    return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
-      .then((project) => {
-        // Currently redirecting to last 2.15 version until we can map old
-        // Ember.* apis with rfc 176 items
-        let lastVersion = '2.15.3';
-        return this.get('store').findRecord('project-version', `ember-${lastVersion}`, { includes: 'project' });
+    return this.get('legacyModuleMappings').fetch()
+      .then((response) => response.json())
+      .then((mappings) => {
+        return {
+          mappings: this.get('legacyModuleMappings').buildMappings(mappings),
+          className: params['class'].substr(0, params['class'].lastIndexOf('.'))
+        }
       })
-      .then((projectVersion) => {
-        let project = projectVersion.get('project');
-        let lastVersion = projectVersion.get('version');
-        //peel off the .html
-        let className = params['class'].substr(0, params['class'].lastIndexOf('.'));
-        let id = `ember-${lastVersion}-${className}`;
-
-        return hash({
-          project: resolve(project),
-          version: resolve(lastVersion),
-          classData: this.store.find('class', id)
-            .then((classData) => {
-              return {
-                type: 'class',
-                data: classData
-              };
-            })
-            .catch(() => {
-              return this.store.find('namespace', id).then((classData) => {
-                return {
-                  type: 'namespace',
-                  data: classData
-                };
-              });
-            })
-        });
-
-      }).catch(e => resolve({ isError: true}));
   },
 
   redirect(model) {
-    if (model.isError) {
-      return this.transitionTo('404');
+    let name = this.get('legacyModuleMappings').getNewClassFromOld(model.className, model.mappings)
+    if (name !== model.className) {
+      return this.transitionTo(`project-version.classes.class`,
+        'ember',
+        'release',
+        name);
     }
-    let compactVersion = getCompactVersion(model.version);
-    return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
-      model.project.id,
-      compactVersion,
-      model.classData.data.get('name'));
-  },
+    return this.transitionTo('project-version', 'ember', 'release')
 
-  serialize(model) {
-    return {
-      namespace: model.classData.get('name')
-    }
   }
 
 });

--- a/app/routes/data-class.js
+++ b/app/routes/data-class.js
@@ -1,56 +1,31 @@
-import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import { pluralize } from 'ember-inflector';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
 
+  legacyModuleMappings: service(),
+
   model(params) {
-    return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
-      .then((project) => {
-        let lastVersion = '2.15.3';
-        return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
+    return this.get('legacyModuleMappings').fetch()
+      .then((response) => response.json())
+      .then((mappings) => {
+        return {
+          mappings: this.get('legacyModuleMappings').buildMappings(mappings),
+          className: params['class'].substr(0, params['class'].lastIndexOf('.'))
+        }
       })
-      .then((projectVersion) => {
-        let project = projectVersion.get('project');
-        let lastVersion = projectVersion.get('version');
-        let className = params['class'].substr(0, params['class'].lastIndexOf('.'));
-        let id = `ember-data-${lastVersion}-${className}`;
-        return hash({
-          project: resolve(project),
-          version: resolve(lastVersion),
-          classData: this.store.find('class', id)
-            .then((classData) => {
-              return {
-                type: 'class',
-                data: classData
-              };
-            })
-            .catch(() => {
-              return this.store.find('namespace', id).then((classData) => {
-                return {
-                  type: 'namespace',
-                  data: classData
-                };
-              });
-            })
-        }).catch(e => resolve({isError: true}));
-      });
   },
 
   redirect(model) {
-    if (model.isError) {
-      return this.transitionTo('404');
+    let name = this.get('legacyModuleMappings').getNewClassFromOld(model.className, model.mappings)
+    if (name !== model.className) {
+      return this.transitionTo(`project-version.classes.class`,
+        'ember-data',
+        'release',
+        name);
     }
-    return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
-      model.project.id,
-      model.version,
-      model.classData.data.get('name'));
-  },
+    return this.transitionTo('project-version', 'ember-data', 'release');
 
-  serialize(model) {
-    return {
-      namespace: model.classData.get('name')
-    }
   }
 
 });

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -1,47 +1,30 @@
-import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-
-import { pluralize } from 'ember-inflector';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
 
-  model(params) {
-    return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
-      .then(project => {
-        let lastVersion = '2.15.3';
-        return this.get('store').findRecord('project-version', `ember-${lastVersion}`, { includes: 'project' });
-      })
-      .then((projectVersion) => {
-        let project = projectVersion.get('project');
-        let lastVersion = projectVersion.get('version');
-        let className = params['module'].substr(0, params['module'].lastIndexOf('.'));
-        let id = `ember-${lastVersion}-${className}`;
+  legacyModuleMappings: service(),
 
-        return hash({
-          project: resolve(project),
-          version: resolve(lastVersion),
-          classData: this.store.find('module', id)
-            .then(classData => {
-              return { type: 'module', data: classData };
-            })
-        }).catch(e => resolve({isError:true}));
-      }).catch(e => resolve({isError:true}));
+  model(params) {
+    return this.get('legacyModuleMappings').fetch()
+      .then((response) => response.json())
+      .then((mappings) => {
+        return {
+          moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
+          mappings: this.get('legacyModuleMappings').buildMappings(mappings)
+        }
+      })
   },
 
   redirect(model) {
-    if (model.isError) {
-      return this.transitionTo('404');
+    let name = this.get('legacyModuleMappings').getNewModuleFromOld(model.moduleName, model.mappings);
+    if (name !== model.moduleName) {
+      return this.transitionTo(`project-version.modules.module`,
+        'ember',
+        'release',
+        name);
     }
-    return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
-      model.project.id,
-      model.version,
-      model.classData.data.get('name'));
-  },
-
-  serialize(model) {
-    return {
-      namespace: model.classData.get('name')
-    }
+    return this.transitionTo('project-version', 'ember', 'release');
   }
 
 });

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-cli-template-lint": "^0.7.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "^2.0.3",
-    "ember-concurrency": "^0.8.12",
+    "ember-concurrency": "0.8.18",
     "ember-data": "^2.14.8",
     "ember-data-fastboot": "0.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,6 +3462,14 @@ ember-composable-helpers@^2.0.3:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"
 
+ember-concurrency@0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.18.tgz#20a9ac4ced6496ea4ebe52e88f4524a473871396"
+  dependencies:
+    babel-core "^6.24.1"
+    ember-cli-babel "^6.8.2"
+    ember-maybe-import-regenerator "^0.1.5"
+
 ember-concurrency@^0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.12.tgz#fb91180e5efeb1024cfa2cfb99d2fe6721930c91"


### PR DESCRIPTION
forwards legacy requests to current release.  seems to be working well.  Much less funky than before