### PR TITLE
Revert "wip: convert legacy urls to "release" route instead of 2.15"

### DIFF
--- a/app/routes/data-class.js
+++ b/app/routes/data-class.js
@@ -1,31 +1,56 @@
+import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
 
-  legacyModuleMappings: service(),
-
   model(params) {
-    return this.get('legacyModuleMappings').fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        return {
-          mappings: this.get('legacyModuleMappings').buildMappings(mappings),
-          className: params['class'].substr(0, params['class'].lastIndexOf('.'))
-        }
+    return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
+      .then((project) => {
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
       })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
+        let className = params['class'].substr(0, params['class'].lastIndexOf('.'));
+        let id = `ember-data-${lastVersion}-${className}`;
+        return hash({
+          project: resolve(project),
+          version: resolve(lastVersion),
+          classData: this.store.find('class', id)
+            .then((classData) => {
+              return {
+                type: 'class',
+                data: classData
+              };
+            })
+            .catch(() => {
+              return this.store.find('namespace', id).then((classData) => {
+                return {
+                  type: 'namespace',
+                  data: classData
+                };
+              });
+            })
+        }).catch(e => resolve({isError: true}));
+      });
   },
 
   redirect(model) {
-    let name = this.get('legacyModuleMappings').getNewClassFromOld(model.className, model.mappings)
-    if (name !== model.className) {
-      return this.transitionTo(`project-version.classes.class`,
-        'ember-data',
-        'release',
-        name);
+    if (model.isError) {
+      return this.transitionTo('404');
     }
-    return this.transitionTo('project-version', 'ember-data', 'release');
+    return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
+      model.project.id,
+      model.version,
+      model.classData.data.get('name'));
+  },
 
+  serialize(model) {
+    return {
+      namespace: model.classData.get('name')
+    }
   }
 
 });

--- a/app/routes/data-module.js
+++ b/app/routes/data-module.js
@@ -1,30 +1,48 @@
+import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
 
-  legacyModuleMappings: service(),
-
   model(params) {
-    return this.get('legacyModuleMappings').fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        return {
-          moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
-          mappings: this.get('legacyModuleMappings').buildMappings(mappings)
-        }
-      });
+    return this.get('store').findRecord('project', 'ember-data', { includes: 'project-version' })
+      .then((project) => {
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-data-${lastVersion}`, { includes: 'project' });
+      })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
+        let className = params['module'].substr(0, params['module'].lastIndexOf('.'));
+        let id = `ember-data-${lastVersion}-${className}`;
+        return hash({
+          project: resolve(project),
+          version: resolve(lastVersion),
+          classData: this.store.find('module', id)
+            .then((classData) => {
+              return {
+                type: 'module',
+                data: classData
+              };
+            })
+        }).catch(e => resolve({isError: true}));
+      }).catch(e => resolve({isError: true}));
   },
 
   redirect(model) {
-    let name = this.get('legacyModuleMappings').getNewModuleFromOld(model.moduleName, model.mappings);
-    if (name !== model.moduleName) {
-      return this.transitionTo(`project-version.modules.module`,
-        'ember-data',
-        'release',
-        name);
+    if (model.isError) {
+      return this.transitionTo('404');
     }
-    return this.transitionTo(`project-version`, 'ember-data', 'release');
+    return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
+      model.project.id,
+      model.version,
+      model.classData.data.get('name'));
+  },
+
+  serialize(model) {
+    return {
+      namespace: model.classData.get('name')
+    }
   }
 
 });

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -1,30 +1,47 @@
+import { hash, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+
+import { pluralize } from 'ember-inflector';
 
 export default Route.extend({
 
-  legacyModuleMappings: service(),
-
   model(params) {
-    return this.get('legacyModuleMappings').fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        return {
-          moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
-          mappings: this.get('legacyModuleMappings').buildMappings(mappings)
-        }
+    return this.get('store').findRecord('project', 'ember', { includes: 'project-version' })
+      .then(project => {
+        let lastVersion = '2.15.3';
+        return this.get('store').findRecord('project-version', `ember-${lastVersion}`, { includes: 'project' });
       })
+      .then((projectVersion) => {
+        let project = projectVersion.get('project');
+        let lastVersion = projectVersion.get('version');
+        let className = params['module'].substr(0, params['module'].lastIndexOf('.'));
+        let id = `ember-${lastVersion}-${className}`;
+
+        return hash({
+          project: resolve(project),
+          version: resolve(lastVersion),
+          classData: this.store.find('module', id)
+            .then(classData => {
+              return { type: 'module', data: classData };
+            })
+        }).catch(e => resolve({isError:true}));
+      }).catch(e => resolve({isError:true}));
   },
 
   redirect(model) {
-    let name = this.get('legacyModuleMappings').getNewModuleFromOld(model.moduleName, model.mappings);
-    if (name !== model.moduleName) {
-      return this.transitionTo(`project-version.modules.module`,
-        'ember',
-        'release',
-        name);
+    if (model.isError) {
+      return this.transitionTo('404');
     }
-    return this.transitionTo('project-version', 'ember', 'release');
+    return this.transitionTo(`project-version.${pluralize(model.classData.type)}.${model.classData.type}`,
+      model.project.id,
+      model.version,
+      model.classData.data.get('name'));
+  },
+
+  serialize(model) {
+    return {
+      namespace: model.classData.get('name')
+    }
   }
 
 });

--- a/app/services/legacy-module-mappings.js
+++ b/app/services/legacy-module-mappings.js
@@ -17,28 +17,20 @@ export default Ember.Service.extend({
 
   initMappings: task(function * () {
     try {
-      let response = yield this.fetch();
+      let response = yield fetch(`${config.APP.cdnUrl}/assets/mappings.json`);
       let mappings = yield response.json();
-      let newMappings = this.buildMappings(mappings);
+      let newMappings = mappings.map(item => {
+        let newItem = Object.assign({}, item);
+        if (LOCALNAME_CONVERSIONS[newItem.localName]) {
+          newItem.localName = LOCALNAME_CONVERSIONS[newItem.localName];
+        }
+        return newItem;
+      });
       this.set('mappings', newMappings);
     } catch (e) {
       this.set('mappings', []);
     }
   }),
-
-  buildMappings(mappings) {
-    return mappings.map(item => {
-      let newItem = Object.assign({}, item);
-      if (LOCALNAME_CONVERSIONS[newItem.localName]) {
-        newItem.localName = LOCALNAME_CONVERSIONS[newItem.localName];
-      }
-      return newItem;
-    });
-  },
-
-  fetch() {
-    return fetch(`${config.APP.cdnUrl}/assets/mappings.json`);
-  },
 
   getModule(name, documentedModule) {
     if (!this.get('initMappings.isIdle')) {
@@ -47,17 +39,6 @@ export default Ember.Service.extend({
     let matches = this.mappings.filter(element => element.localName === name);
     return matches.length > 0 ? matches[0].module : documentedModule;
   },
-
-  getNewClassFromOld(oldClassName, mappings) {
-    let matches = mappings.filter(element => element.global === oldClassName);
-    return matches.length > 0 ? matches[0].localName : oldClassName;
-  },
-
-  getNewModuleFromOld(oldModuleName, mappings) {
-    let matches = mappings.filter(element => element.module === oldModuleName);
-    return matches.length > 0 ? matches[0].replacement.module : oldModuleName;
-  },
-
 
   hasFunctionMapping(name, module) {
     if (!this.get('initMappings.isIdle')) {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-cli-template-lint": "^0.7.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "^2.0.3",
-    "ember-concurrency": "0.8.18",
+    "ember-concurrency": "^0.8.12",
     "ember-data": "^2.14.8",
     "ember-data-fastboot": "0.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,14 +3462,6 @@ ember-composable-helpers@^2.0.3:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"
 
-ember-concurrency@0.8.18:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.18.tgz#20a9ac4ced6496ea4ebe52e88f4524a473871396"
-  dependencies:
-    babel-core "^6.24.1"
-    ember-cli-babel "^6.8.2"
-    ember-maybe-import-regenerator "^0.1.5"
-
 ember-concurrency@^0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.12.tgz#fb91180e5efeb1024cfa2cfb99d2fe6721930c91"


### PR DESCRIPTION
Reverts ember-learn/ember-api-docs#506