### PR TITLE
[FIX] Fix issue #543 - update redirect logic for <=2.15 to/from >=2.16

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -34,10 +34,11 @@ export default Route.extend({
     let transitionVersion = this.get('projectService').getUrlVersion();
     if (!classParams && !moduleParams && !namespaceParams && !functionParams) {
       // if there is no class, module, or namespace specified...
-      let latestVersion = getLastVersion(model.get('project.projectVersions'))
-      let isLatestVersion = (transitionVersion === latestVersion || transitionVersion === 'release')
-      let isEmberProject = (model.get('project.id') === "ember")
-      if (isLatestVersion && isEmberProject) {
+      let latestVersion = getLastVersion(model.get('project.projectVersions'));
+      let isLatestVersion = (transitionVersion === latestVersion || transitionVersion === 'release');
+      let isEmberProject = (model.get('project.id') === "ember");
+      let shouldConvertPackages = semverCompare(model.get('version'), '2.16') < 0;
+      if ((!shouldConvertPackages || isLatestVersion) && isEmberProject) {
         // ... and the transition version is the latest release, and the selected docs are
         // ember (not Ember Data), then show the landing page
         return this.transitionTo('project-version.index')
@@ -135,7 +136,8 @@ export default Route.extend({
       // if the user is navigating to/from api versions >= 2.16, take them
       // to the home page instead of trying to translate the url
       let shouldConvertPackages = this.shouldConvertPackages(ver, this.get('projectService.version'));
-      if (!shouldConvertPackages) {
+      let isEmberProject = project === 'ember';
+      if (!isEmberProject || !shouldConvertPackages) {
         this.transitionTo(`/${project}/${projectVersionID}/${endingRoute}`);
       } else {
         this.transitionTo(`/${project}/${projectVersionID}`);

--- a/tests/acceptance/scroll-reset-on-transition-test.js
+++ b/tests/acceptance/scroll-reset-on-transition-test.js
@@ -64,3 +64,14 @@ test('reset scroll on transitions', async function(assert) {
 
   assert.equal($(scrollContainerSelector).scrollTop(), 0, 'scroll position is resetted after visiting route with same tab but different model');
 });
+
+test('reset scroll on transitions when transition between >=2.16 and <=2.15', async function(assert) {
+  await visit('/ember/2.16');
+
+  $(scrollContainerSelector).scrollTop(1000);
+  assert.notEqual($(scrollContainerSelector).scrollTop(), 0, 'scroll position is NOT zero after scroll on fresh visit');
+
+  await visit('/ember/2.15/classes/Ember.View');
+
+  assert.equal($(scrollContainerSelector).scrollTop(), 0, 'scroll position is zero after transition to different route');
+});

--- a/tests/acceptance/scroll-reset-on-transition-test.js
+++ b/tests/acceptance/scroll-reset-on-transition-test.js
@@ -9,7 +9,7 @@ const { scrollContainerSelector } = config.APP;
 moduleForAcceptance('Acceptance | scroll reset on transition');
 
 test('reset scroll on transitions', async function(assert) {
-  await visit('/ember/2.16');
+  await visit('/ember/2.15');
 
   $(scrollContainerSelector).scrollTop(1000);
   assert.notEqual($(scrollContainerSelector).scrollTop(), 0, 'scroll position is NOT zero after scroll on fresh visit');

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -84,11 +84,18 @@ test('switching class properties tab less than 2.16 should retain', async functi
   assert.equal(currentURL(), '/ember/2.11/classes/Ember.Component/properties', 'navigated to v2.11 properties');
 });
 
-test('switching from class version less than 2.16 to class version 2.16 should reset to first module page', async function(assert) {
+test('switching from class version less than 2.16 to class version 2.16 should reset to landing page', async function(assert) {
   await visit('/ember/2.7/classes/Ember.Component');
   assert.equal(currentURL(), '/ember/2.7/classes/Ember.Component', 'navigated to v2.7 class');
   await selectChoose('.select-container', '2.16');
-  assert.equal(currentURL(), '/ember/2.16/modules/@ember%2Fapplication', 'navigated to v2.16 application module');
+  assert.equal(currentURL(), '/ember/2.16', 'navigated to v2.16 landing page');
+});
+
+test('switching from class version less than 2.16 to class version 2.16 should retain if project is ember-data', async function(assert) {
+  await visit('/ember-data/2.7/classes/DS.Adapter');
+  assert.equal(currentURL(), '/ember-data/2.7/classes/DS.Adapter', 'navigated to v2.7 class');
+  await selectChoose('.select-container', '2.16');
+  assert.equal(currentURL(), '/ember-data/2.16/classes/DS.Adapter', 'navigated to v2.16 landing page');
 });
 
 test('switching from class version 2.16 to class version less then 2.16 should reset to first module page', async function (assert) {
@@ -96,4 +103,11 @@ test('switching from class version 2.16 to class version less then 2.16 should r
   assert.equal(currentURL(), '/ember/2.16/classes/Component', 'navigated to v2.16 class');
   await selectChoose('.select-container', '2.11');
   assert.equal(currentURL(), '/ember/2.11/modules/ember', 'navigated to v2.11 ember module');
+});
+
+test('switching from class version 2.16 to class version less then 2.16 should retain if project is ember-data', async function(assert) {
+  await visit('/ember-data/2.16/classes/DS.Adapter');
+  assert.equal(currentURL(), '/ember-data/2.16/classes/DS.Adapter', 'navigated to v2.7 class');
+  await selectChoose('.select-container', '2.11');
+  assert.equal(currentURL(), '/ember-data/2.11/classes/DS.Adapter', 'navigated to v2.16 landing page');
 });


### PR DESCRIPTION
- Allow redirects for <=2.15 to/from >=2.16 if project is ember-data
- Continue to disallow redirects for <=2.15 to/from >=2.16 if project is ember
- Allow landing page to be displayed for versions >=2.16
- Add tests for ember-data version changes

Fixes #543 