### PR TITLE
Remove check for @ember/object/computed to keep it out of contents

### DIFF
--- a/app/templates/components/table-of-contents.hbs
+++ b/app/templates/components/table-of-contents.hbs
@@ -3,13 +3,9 @@
     <a {{action 'toggle' 'modules'}} href="#">Packages</a>
     <ol class="toc-level-1 modules" style="display: block">
       {{#each moduleIDs as |moduleID|}}
-
-        {{#if (not-eq moduleID "@ember/object/computed")}}
-          <li class="toc-level-1" data-test-module={{moduleID}}>
-            {{#link-to 'project-version.modules.module' version moduleID}}{{moduleID}}{{/link-to}}
-          </li>
-        {{/if}}
-
+        <li class="toc-level-1" data-test-module={{moduleID}}>
+          {{#link-to 'project-version.modules.module' version moduleID}}{{moduleID}}{{/link-to}}
+        </li>
       {{/each}}
     </ol>
   </li>


### PR DESCRIPTION
Added a check to keep @ember/object/computed from showing up in TOC until ember source was fixed.  Its since been fixed