### PR TITLE
Search for "not private" instead of "public" because ember data classes have no access

### DIFF
--- a/app/components/search-input.js
+++ b/app/components/search-input.js
@@ -52,7 +52,7 @@ export default Component.extend({
         'hierarchy.lvl2'
       ],
       tagFilters: [`version:${projectVersion}`],
-      facetFilters: ['access:public']
+      facetFilters: ['access:-private']
     };
 
     const searchObj = {


### PR DESCRIPTION
This allows ember data searching