### PR TITLE
Moved css style for the mouse cursor in search results

### DIFF
--- a/app/styles/components/_search-input.scss
+++ b/app/styles/components/_search-input.scss
@@ -68,7 +68,6 @@ $dropdown-min-width-large: 600px;
 // Each suggestion
 .algolia-docsearch-suggestion {
   color: #333;
-  cursor: pointer;
   overflow: hidden;
   border-bottom: 1px solid $color-border;
 }
@@ -126,6 +125,7 @@ $dropdown-min-width-large: 600px;
 
 .algolia-docsearch-suggestion--content {
   padding: 3px 5px;
+  cursor: pointer;
 }
 
 .algolia-docsearch-suggestion--subcategory-inline {


### PR DESCRIPTION
Moved the `cursor:pointer;` to the clickable search results content wrapper.  Now only the links that actually do something will appear as "clickable" to the user.