### PR TITLE
Stop resetting filtering query params on tab change

### DIFF
--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -6,10 +6,9 @@ import { inject as service } from '@ember/service';
 import values from 'npm:lodash.values';
 import groupBy from 'npm:lodash.groupby';
 import semverCompare from 'npm:semver-compare';
-import FilterParams from '../mixins/filter-params';
 import getCompactVersion from '../utils/get-compact-version';
 
-export default Controller.extend(FilterParams, {
+export default Controller.extend({
 
   filterData: service(),
 

--- a/app/controllers/project-version/classes/class.js
+++ b/app/controllers/project-version/classes/class.js
@@ -2,8 +2,9 @@ import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 import ParentNameMixin from 'ember-api-docs/mixins/parent-name';
+import FilterParams from 'ember-api-docs/mixins/filter-params';
 
-export default Controller.extend(ParentNameMixin, {
+export default Controller.extend(ParentNameMixin, FilterParams, {
   filterData: service(),
   legacyModuleMappings: service(),
 


### PR DESCRIPTION
Fixes #515 

I tried to write an acceptance test for this, but I couldn't manage to get one that failed under the old code. This bug is very elusive, and I kind of suspect fastboot might be part of it (although I've never used fastboot so I could be very wrong here).

It seems like sometimes you will load the page and it will work perfectly as intended, and other times the bug will pop up. The best reproductions I've found are either what was said in #515 (opening the url to the class directly in a new tab and then trying the bug), or going to the home page in a fresh tab and then going to the class page. From what I can tell, for some reason in these cases the link-to's never update with new query params on them when the values change, causing the bug.

With that said, this PR has solved the bug in those cases, and I haven't been able to reproduce it with this change, so I figured I would throw it up for y'all to look at and decide what to do. :)