### PR TITLE
revert a couple of css changes

### DIFF
--- a/app/styles/components/_highlight.scss
+++ b/app/styles/components/_highlight.scss
@@ -43,6 +43,7 @@
   table {
     border: none;
     margin: 0;
+    table-layout: auto;
     overflow: auto;
     width: 100%;
     z-index: auto;
@@ -104,7 +105,6 @@
     @include size(52px 20px);
     background: 0 0 no-repeat;
     background-size: 52px 20px;
-    background-color: $code-background;
     z-index: 9;
   }
 


### PR DESCRIPTION
#562 fixed some style issues around the import examples, but a couple of its css changes adversely affected code examples:

![image](https://user-images.githubusercontent.com/3609063/46779975-3c3e6080-cce8-11e8-8b85-5c4d024ad8fd.png)

After this fix:

![image](https://user-images.githubusercontent.com/3609063/46779990-4c564000-cce8-11e8-8d90-33edd4ed0113.png)
