### PR TITLE
Showing pencil link only on current release, and linking to gh edit

### DIFF
--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -1,7 +1,10 @@
 import { helper } from '@ember/component/helper';
 import githubMap from '../utils/github-map';
 
-export function githubLink([project, version, file, line]) {
+export function githubLink([project, version, file, line], { isEdit=false }) {
+  if (isEdit) {
+    return `https://github.com/${githubMap[project]}/edit/release/${file}#L${line}`;
+  }
   return `https://github.com/${githubMap[project]}/tree/v${version}/${file}#L${line}`;
 }
 

--- a/app/helpers/is-latest.js
+++ b/app/helpers/is-latest.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+import getLastVersion from 'ember-api-docs/utils/get-last-version';
+
+export function isLatest(params, { version, allVersions}) {
+  let latestVersion = getLastVersion(allVersions);
+  return version === latestVersion;
+}
+
+export default helper(isLatest);

--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -1,5 +1,7 @@
 <article class="chapter">
-  <a data-tooltip="View on Github" class="heading__link__edit" href="{{github-link model.project.id model.projectVersion.version model.file model.line}}" target="_blank" rel="noopener">{{svg-jar "fa-pencil"}}</a>
+  {{#if (is-latest version=model.projectVersion.version allVersions=model.project.projectVersions)}}
+    <a data-tooltip="Edit on Github" class="heading__link__edit" href="{{github-link model.project.id model.projectVersion.version model.file model.line isEdit=true}}" target="_blank" rel="noopener">{{svg-jar "fa-pencil"}}</a>
+  {{/if}}
   <h1 class="module-name">Class {{model.name}}</h1>
   {{#if model.access}}<span class="access">{{model.access}}</span>{{/if}}
 

--- a/tests/integration/helpers/is-latest-test.js
+++ b/tests/integration/helpers/is-latest-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { A } from '@ember/array';
+
+const versions = A([
+  { id: 'ember-1.13.0' },
+  { id: 'ember-3.5.0' },
+  { id: 'ember-2.1.10' }
+]);
+
+module('helper:is-latest', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('should resolve true if latest release', async function(assert) {
+    this.set('version', '3.5.0');
+    this.set('allVersions', versions);
+
+    await render(hbs`
+  {{#if (is-latest version=version allVersions=allVersions)}}
+    Hello World
+  {{/if}}
+  `);
+
+    assert.equal(this.element.textContent.trim(), 'Hello World');
+  });
+
+  test('should resolve false if not latest', async function (assert) {
+    this.set('version', '3.1.0');
+    this.set('allVersions', versions);
+    await render(hbs`
+  {{#if (is-latest version=version allVersions=allVersions)}}
+    Hello World
+  {{/if}}
+  `);
+    assert.notEqual(this.element.textContent.trim(), 'Hello World');
+  })
+
+});

--- a/tests/unit/helpers/github-link-test.js
+++ b/tests/unit/helpers/github-link-test.js
@@ -4,6 +4,6 @@ import { module, test } from 'qunit';
 module('Unit | Helper | github link');
 
 test('should render a github link from file info', function(assert) {
-  let result = githubLink(['ember', '2.10.0', 'ember-glimmer/lib/component.js', '35']);
+  let result = githubLink(['ember', '2.10.0', 'ember-glimmer/lib/component.js', '35'], {});
   assert.equal(result, 'https://github.com/emberjs/ember.js/tree/v2.10.0/ember-glimmer/lib/component.js#L35');
 });


### PR DESCRIPTION
Turns the pencil icon back into what it always should've been, an actual github edit.  Only doing this for current release. (pencil not shown on previous)

![gh-edit-link](https://user-images.githubusercontent.com/3609063/47478567-bb0ebf80-d7f7-11e8-953a-ad833a466d38.gif)
