### PR TITLE
Fix multiple problems with uses and extends

### DIFF
--- a/app/helpers/project-name-from-class-name.js
+++ b/app/helpers/project-name-from-class-name.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 export function projectNameFromClassName([className, fallback]) {
     className = className || "";
-    if (className.indexOf('Ember.') > -1) {
+    if (className.indexOf('Ember') > -1) {
       return 'ember';
     }
 

--- a/app/helpers/project-name-from-class-name.js
+++ b/app/helpers/project-name-from-class-name.js
@@ -1,0 +1,16 @@
+import { helper } from '@ember/component/helper';
+
+export function projectNameFromClassName([className, fallback]) {
+    className = className || "";
+    if (className.indexOf('Ember.') > -1) {
+      return 'ember';
+    }
+
+    if (className.indexOf('DS.') > -1) {
+      return 'ember-data';
+    }
+
+    return fallback;
+}
+
+export default helper(projectNameFromClassName);

--- a/app/helpers/remove-ember-prefix.js
+++ b/app/helpers/remove-ember-prefix.js
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+
+export function removeEmberPrefix(params/*, hash*/) {
+  let ext = params[0]; 
+  // Ember doesn't use the Ember prefix on all Classes
+  if(ext.indexOf('.')>=0 && ext.substring(0,5) === 'Ember'){
+    // return ext.replace('.','');
+    return ext.slice(6);
+  }
+  else{
+    return ext;
+  }
+}
+
+export default helper(removeEmberPrefix);

--- a/app/models/class.js
+++ b/app/models/class.js
@@ -9,7 +9,7 @@ const projectNameFromClassName = key => {
       return 'ember';
     }
 
-    if (value.indexOf('DS.') > 1) {
+    if (value.indexOf('DS.') > -1) {
       return 'ember-data';
     }
 

--- a/app/models/class.js
+++ b/app/models/class.js
@@ -5,7 +5,7 @@ const {attr, belongsTo} = DS;
 const projectNameFromClassName = key => {
   return computed(key, function() {
     const value = this.get(key) || "";
-    if (value.indexOf('Ember.') > -1) {
+    if (value.indexOf('Ember') > -1) {
       return 'ember';
     }
 

--- a/app/models/class.js
+++ b/app/models/class.js
@@ -51,7 +51,6 @@ export default DS.Model.extend({
 
   extendedClassProjectName: projectNameFromClassName('extends'),
   extendedClassVersion: guessVersionFor('extends'),
-  usedClassProjectName: projectNameFromClassName('uses'),
   usedClassVersion: guessVersionFor('uses')
 
 });

--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -18,7 +18,7 @@
         <span class="attribute-value">
           {{#each model.uses as |parentClass idx|}}
             {{#if (not-eq idx 0)}}<span class="comma">,</span>{{/if}}
-            {{#link-to 'project-version.classes.class' model.usedClassProjectName model.projectVersion.compactVersion (remove-ember-prefix parentClass)}}{{parentClass}}{{/link-to}}
+              {{#link-to 'project-version.classes.class' (project-name-from-class-name parentClass model.project.id) model.projectVersion.compactVersion (remove-ember-prefix parentClass)}}{{parentClass}}{{/link-to}}
           {{/each}}
         </span>
       </div>

--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -9,7 +9,7 @@
     {{#if model.extends}}
       <div class="attribute">
         <span class="attribute-label">Extends:</span>
-        <span class="attribute-value">{{#link-to 'project-version.classes.class' model.extendedClassProjectName model.projectVersion.compactVersion model.extends}}{{model.extends}}{{/link-to}}</span>
+        <span class="attribute-value">{{#link-to 'project-version.classes.class' model.extendedClassProjectName model.projectVersion.compactVersion (remove-ember-prefix model.extends)}}{{model.extends}}{{/link-to}}</span>
       </div>
     {{/if}}
     {{#if model.uses}}
@@ -18,7 +18,7 @@
         <span class="attribute-value">
           {{#each model.uses as |parentClass idx|}}
             {{#if (not-eq idx 0)}}<span class="comma">,</span>{{/if}}
-            {{#link-to 'project-version.classes.class' model.usedClassProjectName model.projectVersion.compactVersion parentClass}}{{parentClass}}{{/link-to}}
+            {{#link-to 'project-version.classes.class' model.usedClassProjectName model.projectVersion.compactVersion (remove-ember-prefix parentClass)}}{{parentClass}}{{/link-to}}
           {{/each}}
         </span>
       </div>

--- a/tests/integration/helpers/remove-ember-prefix-test.js
+++ b/tests/integration/helpers/remove-ember-prefix-test.js
@@ -1,0 +1,31 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('remove-ember-prefix', 'helper:remove-ember-prefix', {
+  integration: true
+});
+
+
+test('it doesn\'t remove DS prefix', function(assert) {
+  this.set('inputValue', 'DS.Error');
+
+  this.render(hbs`{{remove-ember-prefix inputValue}}`);
+
+  assert.equal(this.$().text().trim(), 'DS.Error');
+});
+
+test('it does remove `Ember.` prefix ', function(assert) {
+  this.set('inputValue', 'Ember.ArrayProxy');
+
+  this.render(hbs`{{remove-ember-prefix inputValue}}`);
+
+  assert.equal(this.$().text().trim(), 'ArrayProxy');
+});
+
+test('it doesn\'t remove `Ember` prefix', function(assert) {
+  this.set('inputValue', 'EmberArray');
+
+  this.render(hbs`{{remove-ember-prefix inputValue}}`);
+
+  assert.equal(this.$().text().trim(), 'EmberArray');
+});

--- a/tests/unit/helpers/project-name-from-class-name-test.js
+++ b/tests/unit/helpers/project-name-from-class-name-test.js
@@ -1,0 +1,20 @@
+import { projectNameFromClassName } from 'ember-api-docs/helpers/project-name-from-class-name';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | project name from class name');
+
+test('it should find ember project name', function(assert) {
+  const result = projectNameFromClassName(['Ember.SomeClass', 'fallback']);
+    console.log(result);
+  assert.equal(result, 'ember');
+});
+
+test('it should find ember-data project name', function(assert) {
+  const result = projectNameFromClassName(['DS.SomeClass', 'fallback']);
+  assert.equal(result, 'ember-data');
+});
+
+test('it should find fallback project name', function(assert) {
+  const result = projectNameFromClassName(['Other.SomeClass', 'fallback']);
+  assert.equal(result, 'fallback');
+});

--- a/tests/unit/helpers/project-name-from-class-name-test.js
+++ b/tests/unit/helpers/project-name-from-class-name-test.js
@@ -5,7 +5,6 @@ module('Unit | Helper | project name from class name');
 
 test('it should find ember project name', function(assert) {
   const result = projectNameFromClassName(['Ember.SomeClass', 'fallback']);
-    console.log(result);
   assert.equal(result, 'ember');
 });
 


### PR DESCRIPTION
As described in the Issue https://github.com/ember-learn/ember-api-docs/issues/532 the links created for the Class [`DS.RecordArray`](https://emberjs.com/api/ember-data/3.5/classes/DS.RecordArray) are wrong. 
Instead linking to 

/api/ember/3.5/classes/**Ember.ArrayProxy** and /api/**ember-data**/3.5/classes/Ember.Evented 
when they should link to 
/api/ember/3.5/classes/**ArrayProxy** and /api/**ember**/3.5/classes/Evented

This is achieved by creating a new helper that removes the `Ember.` prefix and an update to the `projectNameFromClassName()` function.

Remaining problems (not caused by this PR):
- [x] class model only has single value for `usedClassProjectName` where the basis for the creation of that prop is a array with possibly multiple entries
- [x] Some Classes extend from the "wrong" Classes, e.g. `DS.Adapter` uses Ember.Object where it should be EmberObject. I will try and find many errors like this in another PR in ember-data source.
