### PR TITLE
Add CLI guides to the navbar

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -5,11 +5,15 @@ const links = [{
   type: 'dropdown',
   items: [{
     href: 'https://guides.emberjs.com',
-    name: 'Guides',
+    name: 'Ember.js Guides',
     type: 'link'
   }, {
     href: 'https://emberjs.com/api',
     name: 'API Reference',
+    type: 'link'
+  }, {
+    href: 'https://cli.emberjs.com',
+    name: 'CLI Guides',
     type: 'link'
   }, {
     type: 'divider'

--- a/app/templates/project-version/index.hbs
+++ b/app/templates/project-version/index.hbs
@@ -5,7 +5,7 @@
     from the dropdown menu. Ember has core methods used in any app, while Ember Data has 
     documentation of the built-in library for making requests to a back end.
     If you're looking for documentation of the command line tool used to generate files, build your 
-    app, and more, visit <a href="https://ember-cli.com/">ember-cli</a>. The latest
+    app, and more, visit <a href="https://cli.emberjs.com/">ember-cli</a>. The latest
     testing API is available at 
     <a href="https://github.com/emberjs/ember-test-helpers/blob/master/API.md">ember-test-helpers</a>.
   </p>


### PR DESCRIPTION
I have added the CLI guides to the "Docs" dropdown, and clarified "The Guides" as "Ember.js Guides".

I did not add a link to the CLI Guides API because I think it's ok for someone to get to it via the Guides. The CLI API docs also need some kind of review before they are included in the top navbar.

"The Guides" are really "The Ember.js Guides" because as we make more guides (like Ember Data, Ember CLI, etc) we need more granular descriptions.

These 3 PRs should be merged at the same time:
1. ember-styleguide https://github.com/ember-learn/ember-styleguide/pull/115
2. ember-api-docs https://github.com/ember-learn/ember-api-docs/pull/576
3. website https://github.com/emberjs/website/pull/3705