### PR TITLE
Trim the inner text used to assert url value

### DIFF
--- a/tests/acceptance/anchors-test.js
+++ b/tests/acceptance/anchors-test.js
@@ -8,5 +8,5 @@ test('Can create a link from the "Properties" tab', async function(assert) {
   await visit('/ember/1.0/classes/Container/properties');
   let [ element ] = findAll('.class-field-description--link');
   await click(element);
-  assert.equal(currentURL(), `/ember/1.0/classes/Container/properties?anchor=${element.innerText}`);
+  assert.equal(currentURL(), `/ember/1.0/classes/Container/properties?anchor=${element.innerText.trim()}`);
 });


### PR DESCRIPTION
fixes a failure in travis testing:
![image](https://user-images.githubusercontent.com/3609063/55211707-98783c80-51c3-11e9-9d22-64305dbb62f7.png)
