### PR TITLE
 Fix version switching for class names that contains slashes

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { computed }  from '@ember/object';
 import semverCompare from 'npm:semver-compare';
 import getCompactVersion from 'ember-api-docs/utils/get-compact-version';
 import getFullVersion from 'ember-api-docs/utils/get-full-version';
@@ -78,6 +77,11 @@ export default Route.extend({
     }
   },
 
+  _getEncodedNameForCurrentClass() {
+    // escape any reserved characters for url, like slashes
+    return encodeURIComponent(this.modelFor('project-version.classes.class').get('name'));
+  },
+
   serialize(model) {
     return {
       project: model.get('project.id'),
@@ -85,23 +89,18 @@ export default Route.extend({
     };
   },
 
-  encodedNameForCurrentClass: computed(function () {
-    // escape any reserved characters for url, like slashes
-    return encodeURIComponent(this.modelFor('project-version.classes.class').get('name'));
-  }),
-
   actions: {
     updateProject(project, ver /*, component */) {
       let projectVersionID = ver.compactVersion;
       let endingRoute;
       switch ((this.router.currentRouteName)) {
         case 'project-version.classes.class': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           endingRoute = `classes/${className}`;
           break;
         }
         case 'project-version.classes.class.index': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           endingRoute = `classes/${className}`;
           break;
         }
@@ -118,34 +117,34 @@ export default Route.extend({
           break;
         }
         case 'project-version.classes.class.methods.index': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           endingRoute = `classes/${className}/methods`;
           break;
         }
         case 'project-version.classes.class.events.index': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           endingRoute = `classes/${className}/events`;
           break;
         }
         case 'project-version.classes.class.properties.index': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           endingRoute = `classes/${className}/properties`;
           break;
         }
         case 'project-version.classes.class.methods.method': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           let methodName = this.paramsFor('project-version.classes.class.methods.method').method;
           endingRoute = `classes/${className}/methods/${methodName}?anchor=${methodName}`;
           break;
         }
         case 'project-version.classes.class.events.event': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           let eventName = this.paramsFor('project-version.classes.class.events.event').event;
           endingRoute = `classes/${className}/events/${eventName}?anchor=${eventName}`;
           break;
         }
         case 'project-version.classes.class.properties.property': {
-          let className = this.get('encodedNameForCurrentClass');
+          let className = this._getEncodedNameForCurrentClass();
           let propertyName = this.paramsFor('project-version.classes.class.properties.property')
             .property;
           endingRoute = `classes/${className}/properties/${propertyName}?anchor=${propertyName}`;

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { computed }  from '@ember/object';
 import semverCompare from 'npm:semver-compare';
 import getCompactVersion from 'ember-api-docs/utils/get-compact-version';
 import getFullVersion from 'ember-api-docs/utils/get-full-version';
@@ -84,18 +85,23 @@ export default Route.extend({
     };
   },
 
+  encodedNameForCurrentClass: computed(function () {
+    // escape any reserved characters for url, like slashes
+    return encodeURIComponent(this.modelFor('project-version.classes.class').get('name'));
+  }),
+
   actions: {
     updateProject(project, ver /*, component */) {
       let projectVersionID = ver.compactVersion;
-      let endingRoute, routeName;
-      switch ((routeName = this.router.currentRouteName)) {
+      let endingRoute;
+      switch ((this.router.currentRouteName)) {
         case 'project-version.classes.class': {
-          let className = this.modelFor(routeName).get('name');
+          let className = this.get('encodedNameForCurrentClass');
           endingRoute = `classes/${className}`;
           break;
         }
         case 'project-version.classes.class.index': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           endingRoute = `classes/${className}`;
           break;
         }
@@ -112,34 +118,34 @@ export default Route.extend({
           break;
         }
         case 'project-version.classes.class.methods.index': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           endingRoute = `classes/${className}/methods`;
           break;
         }
         case 'project-version.classes.class.events.index': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           endingRoute = `classes/${className}/events`;
           break;
         }
         case 'project-version.classes.class.properties.index': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           endingRoute = `classes/${className}/properties`;
           break;
         }
         case 'project-version.classes.class.methods.method': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           let methodName = this.paramsFor('project-version.classes.class.methods.method').method;
           endingRoute = `classes/${className}/methods/${methodName}?anchor=${methodName}`;
           break;
         }
         case 'project-version.classes.class.events.event': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           let eventName = this.paramsFor('project-version.classes.class.events.event').event;
           endingRoute = `classes/${className}/events/${eventName}?anchor=${eventName}`;
           break;
         }
         case 'project-version.classes.class.properties.property': {
-          let className = this.modelFor('project-version.classes.class').get('name');
+          let className = this.get('encodedNameForCurrentClass');
           let propertyName = this.paramsFor('project-version.classes.class.properties.property')
             .property;
           endingRoute = `classes/${className}/properties/${propertyName}?anchor=${propertyName}`;

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -124,8 +124,6 @@ test(`switching versions works if we've previously switched for a different clas
   assert.equal(currentURL(), '/ember/3.4/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.4 class');
   await selectChoose('.select-container', '3.7');
   assert.equal(currentURL(), '/ember/3.7/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.7 class');
-  // debugger;
-  // await click('[data-test-class="Component"]');
   await visit('/ember/3.7/classes/Component');
   assert.equal(currentURL(), '/ember/3.7/classes/Component', 'navigated to new class');
   await selectChoose('.select-container', '2.18');

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -112,9 +112,9 @@ test('switching from class version 2.16 to class version less then 2.16 should r
   assert.equal(currentURL(), '/ember-data/2.11/classes/DS.Adapter', 'navigated to v2.16 landing page');
 });
 
-test('switching versions from class works if path contains encoded slashes', async function(assert) {
-  await visit('ember/3.4/classes/@ember%2Fobject%2Fcomputed/');
-  assert.equal(currentURL(), 'ember/3.4/classes/@ember%2Fobject%2Fcomputed/', 'navigated to v3.4 class');
+test('switching versions works if class name includes slashes', async function(assert) {
+  await visit('/ember/3.4/classes/@ember%2Fobject%2Fcomputed');
+  assert.equal(currentURL(), '/ember/3.4/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.4 class');
   await selectChoose('.select-container', '3.7');
-  assert.equal(currentURL(), 'ember/3.7/classes/@ember%2Fobject%2Fcomputed/', 'navigated to v3.7 class');
+  assert.equal(currentURL(), '/ember/3.7/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.7 class');
 });

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -118,3 +118,16 @@ test('switching versions works if class name includes slashes', async function(a
   await selectChoose('.select-container', '3.7');
   assert.equal(currentURL(), '/ember/3.7/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.7 class');
 });
+
+test(`switching versions works if we've previously switched for a different class`, async function(assert) {
+  await visit('/ember/3.4/classes/@ember%2Fobject%2Fcomputed');
+  assert.equal(currentURL(), '/ember/3.4/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.4 class');
+  await selectChoose('.select-container', '3.7');
+  assert.equal(currentURL(), '/ember/3.7/classes/@ember%2Fobject%2Fcomputed', 'navigated to v3.7 class');
+  // debugger;
+  // await click('[data-test-class="Component"]');
+  await visit('/ember/3.7/classes/Component');
+  assert.equal(currentURL(), '/ember/3.7/classes/Component', 'navigated to new class');
+  await selectChoose('.select-container', '2.18');
+  assert.equal(currentURL(), '/ember/2.18/classes/Component', 'navigated to v2.18 for new class');
+});

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -111,3 +111,10 @@ test('switching from class version 2.16 to class version less then 2.16 should r
   await selectChoose('.select-container', '2.11');
   assert.equal(currentURL(), '/ember-data/2.11/classes/DS.Adapter', 'navigated to v2.16 landing page');
 });
+
+test('switching versions from class works if path contains encoded slashes', async function(assert) {
+  await visit('ember/3.4/classes/@ember%2Fobject%2Fcomputed/');
+  assert.equal(currentURL(), 'ember/3.4/classes/@ember%2Fobject%2Fcomputed/', 'navigated to v3.4 class');
+  await selectChoose('.select-container', '3.7');
+  assert.equal(currentURL(), 'ember/3.7/classes/@ember%2Fobject%2Fcomputed/', 'navigated to v3.7 class');
+});


### PR DESCRIPTION
This fixes version switching for classes whose name contains slashes, like `@ember/object/computed`

### Reproduction Steps:
1. visit https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/
2. use the version switching dropdown to select version 3.7

Before this fix, you'll notice that no navigation takes place, and you remain on 3.4.  This is because the class's `name` is `@ember/object/computed`, and when the router tries to transition, it treats the slashes as subroutes in the url and can't find a route.

I fixed this by first wrapping the class name in `encodeURIComponent` before transitioning.