### PR TITLE
Removing jQuery usage from app

### DIFF
--- a/app/components/ember-anchor.js
+++ b/app/components/ember-anchor.js
@@ -1,18 +1,28 @@
-import $ from 'jquery';
 import { get } from '@ember/object';
 import AnchorComponent from 'ember-anchor/components/ember-anchor';
 import config from 'ember-api-docs/config/environment';
 
 export default AnchorComponent.extend({
+  getOffset(element, container) {
+    let offsetTop = element.offsetTop;
+    let parent = element.offsetParent;
+    while (parent != null && parent != container) {
+      offsetTop  += parent.offsetTop;
+      parent = parent.offsetParent;
+    }
+    return offsetTop;
+  },
 
   // This overrides Ember Anchor to support scrolling within a fixed position element
   _scrollToElemPosition() {
     let qp = this.anchorQueryParam;
     let qpVal = this.get(get(this, 'attrs.a') ? 'a' : `controller.${qp}`);
-    let elem = $(`[data-${qp}="${qpVal}"]`);
-    let offset = elem.offset() ? elem.offset().top : 0;
+    let elem = document.querySelector(`[data-${qp}="${qpVal}"]`);
+    let offset = elem.offsetHeight ? elem.offsetHeight : 0;
+
     if (offset) {
-      $(config.APP.scrollContainerSelector).scrollTop(offset);
+      const offsetTop = this.getOffset(elem, config.APP.scrollContainerSelector)
+      document.querySelector(config.APP.scrollContainerSelector).scrollTo(0, offsetTop);
     }
   }
 });

--- a/app/components/ember-anchor.js
+++ b/app/components/ember-anchor.js
@@ -9,9 +9,8 @@ export default AnchorComponent.extend({
     let qp = this.anchorQueryParam;
     let qpVal = this.get(get(this, 'attrs.a') ? 'a' : `controller.${qp}`);
     let elem = document.querySelector(`[data-${qp}="${qpVal}"]`);
-    const offsetTop = elem.offsetHeight;
 
-    if (offsetTop) {
+    if (elem && elem.offsetHeight) {
       const offsetToScroll = getOffset(elem, config.APP.scrollContainerSelector)
       document.querySelector(config.APP.scrollContainerSelector).scrollTo(0, offsetToScroll);
     }

--- a/app/components/ember-anchor.js
+++ b/app/components/ember-anchor.js
@@ -1,28 +1,19 @@
 import { get } from '@ember/object';
 import AnchorComponent from 'ember-anchor/components/ember-anchor';
 import config from 'ember-api-docs/config/environment';
+import getOffset from 'ember-api-docs/utils/get-offset';
 
 export default AnchorComponent.extend({
-  getOffset(element, container) {
-    let offsetTop = element.offsetTop;
-    let parent = element.offsetParent;
-    while (parent != null && parent != container) {
-      offsetTop  += parent.offsetTop;
-      parent = parent.offsetParent;
-    }
-    return offsetTop;
-  },
-
   // This overrides Ember Anchor to support scrolling within a fixed position element
   _scrollToElemPosition() {
     let qp = this.anchorQueryParam;
     let qpVal = this.get(get(this, 'attrs.a') ? 'a' : `controller.${qp}`);
     let elem = document.querySelector(`[data-${qp}="${qpVal}"]`);
-    let offset = elem.offsetHeight ? elem.offsetHeight : 0;
+    const offsetTop = elem.offsetHeight;
 
-    if (offset) {
-      const offsetTop = this.getOffset(elem, config.APP.scrollContainerSelector)
-      document.querySelector(config.APP.scrollContainerSelector).scrollTo(0, offsetTop);
+    if (offsetTop) {
+      const offsetToScroll = getOffset(elem, config.APP.scrollContainerSelector)
+      document.querySelector(config.APP.scrollContainerSelector).scrollTo(0, offsetToScroll);
     }
   }
 });

--- a/app/mixins/scroll-tracker.js
+++ b/app/mixins/scroll-tracker.js
@@ -16,9 +16,8 @@ export default Mixin.create({
       this._super();
       if ((typeof FastBoot === 'undefined') && window.location.search === '?anchor=' ) {
         let elem = document.querySelector('#methods');
-        let offsetTop = elem.offsetHeight;
 
-        if (offsetTop) {
+        if (elem && elem.offsetHeight) {
           const offsetToScroll = getOffset(elem, config.APP.scrollContainerSelector)
           document.querySelector(config.APP.scrollContainerSelector).scrollTo(0, offsetToScroll - 10);
           return;

--- a/app/mixins/scroll-tracker.js
+++ b/app/mixins/scroll-tracker.js
@@ -1,7 +1,7 @@
 import Mixin from '@ember/object/mixin';
 import { inject as service } from '@ember/service';
-import $ from 'jquery';
 import config from 'ember-api-docs/config/environment';
+import getOffset from 'ember-api-docs/utils/get-offset';
 
 export default Mixin.create({
 
@@ -15,10 +15,12 @@ export default Mixin.create({
     didTransition() {
       this._super();
       if ((typeof FastBoot === 'undefined') && window.location.search === '?anchor=' ) {
-        let elem = $('#methods');
-        let offset = elem.offset() ? elem.offset().top : 0;
-        if (offset) {
-          $(config.APP.scrollContainerSelector).scrollTop(offset - 10);
+        let elem = document.querySelector('#methods');
+        let offsetTop = elem.offsetHeight;
+
+        if (offsetTop) {
+          const offsetToScroll = getOffset(elem, config.APP.scrollContainerSelector)
+          document.querySelector(config.APP.scrollContainerSelector).scrollTo(0, offsetToScroll - 10);
           return;
         }
       }

--- a/app/services/scroll-position-reset.js
+++ b/app/services/scroll-position-reset.js
@@ -1,5 +1,4 @@
 import Service from '@ember/service';
-import $ from 'jquery';
 import config from 'ember-api-docs/config/environment';
 
 const { scrollContainerSelector } = config.APP;
@@ -27,7 +26,8 @@ export default Service.extend({
 
   doReset() {
     if (this._shouldResetScroll) {
-      $(scrollContainerSelector).scrollTop(0);
+      const selector = document.querySelector(scrollContainerSelector);
+      selector.scrollTo(0,0);
       this.set('_shouldResetScroll', false);
     }
   }

--- a/app/utils/get-offset.js
+++ b/app/utils/get-offset.js
@@ -1,0 +1,9 @@
+export default function getOffset(element, container) {
+  let offsetTop = element.offsetTop;
+  let parent = element.offsetParent;
+  while (parent != null && parent != container) {
+    offsetTop  += parent.offsetTop;
+    parent = parent.offsetParent;
+  }
+  return offsetTop;
+}


### PR DESCRIPTION
After removing jquery usage from test, this PR aims to remove jquery usage in the app.

TODO : 
- [x] app/components/ember-anchor.js

- [x] app/services/scroll-position-reset.js

- [x] app/mixins/scroll-tracker.js

Related issue https://github.com/ember-learn/ember-api-docs/issues/441