### PR TITLE
Revert "feat: sticky method, property, and event headers (#336)"

### DIFF
--- a/app/components/class-field-description.js
+++ b/app/components/class-field-description.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { gt } from '@ember/object/computed';
 
 export default Component.extend({
   legacyModuleMappings: service(),
@@ -9,17 +8,6 @@ export default Component.extend({
   hasImportExample: computed('field.{name,class}', function () {
     return this.legacyModuleMappings.hasFunctionMapping(this.get('field.name'), this.get('field.class'));
   }),
-
-  stickyEnabled: gt('ownHeight', 200),
-
-  didInsertElement() {
-    this._super(...arguments);
-    this.setOwnHeight(this.element);
-  },
-
-  setOwnHeight(element) {
-    this.set('ownHeight', element.clientHeight);
-  },
 
   /**
    * Callback for updating the anchor with the field name that was clicked by a user.

--- a/app/styles/components/_class-field-desc.scss
+++ b/app/styles/components/_class-field-desc.scss
@@ -17,14 +17,6 @@
   font-size: $base-font-size;
 }
 
-.sticky-element--sticky .class-field-description--link {
-  margin: 0 -1.45em;
-  background-color: #FDFDFD;
-  padding: 0.4em 1.4em;
-  box-shadow: rgba(0, 0, 0, 0.4) 0 1px 4px -1px;
-  transition: 0.3s top, 0.3s box-shadow, 0.3s padding;
-}
-
 .class-field-description--link .return-type,
 .return .return-type,
 .parameter .parameter-type {
@@ -62,7 +54,6 @@ h3 .access{
 
 .method, .property, .event {
   border-bottom: $base-border;
-  position: relative;
 
   .method-name, .property-name, .event-name {
     font-family: $monospace-font-family;

--- a/app/styles/components/_highlight.scss
+++ b/app/styles/components/_highlight.scss
@@ -8,7 +8,6 @@
   margin: $small-spacing 0 $large-spacing;
   overflow: hidden;
   position: relative;
-  z-index: -1;
 
   &.handlebars {
     .inline,

--- a/app/templates/components/class-field-description.hbs
+++ b/app/templates/components/class-field-description.hbs
@@ -1,26 +1,24 @@
 <section class="{{type}}">
-  {{#sticky-element top=0 bottom=0 enabled=this.stickyEnabled}}
-    <h3 class="class-field-description--link" data-anchor="{{field.name}}" role="link" onclick={{action updateAnchor field.name}}>
-      <a class="anchor">
-        {{svg-jar 'fa-link' class="class-field-description--link-hover" width="20px" height="20px"}}
-      </a>
-      <span class="{{type}}-name">{{field.name}}</span>
-      {{#if field.params}}
-        <span class="args">
-          ({{join ", " (map-by "name" field.params)}})
-        </span>
-      {{/if}}
-      {{#if field.return}}
-        <span class="return-type">{{field.return.type}}</span>
-      {{/if}}
-      {{#if field.access}}
-        <span class="access">{{field.access}}</span>
-      {{/if}}
-      {{#if field.deprecated}}
-        <span class="access">deprecated</span>
-      {{/if}}
-    </h3>
-  {{/sticky-element}}
+  <h3 class="class-field-description--link" data-anchor="{{field.name}}" role="link" onclick={{action updateAnchor field.name}}>
+    <a class="anchor">
+      {{svg-jar 'fa-link' class="class-field-description--link-hover" width="20px" height="20px"}}
+    </a>
+    <span class="{{type}}-name">{{field.name}}</span>
+    {{#if field.params}}
+      <span class="args">
+        ({{join ", " (map-by "name" field.params)}})
+      </span>
+    {{/if}}
+    {{#if field.return}}
+      <span class="return-type">{{field.return.type}}</span>
+    {{/if}}
+    {{#if field.access}}
+      <span class="access">{{field.access}}</span>
+    {{/if}}
+    {{#if field.deprecated}}
+      <span class="access">deprecated</span>
+    {{/if}}
+  </h3>
   {{#if model.module}}
     <div class="attributes">
       <div class="attribute">

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "ember-route-action-helper": "^2.0.5",
     "ember-sinon": "^2.1.0",
     "ember-source": "~3.4.0",
-    "ember-sticky-element": "^0.2.3",
     "ember-styleguide": "^2.3.1",
     "ember-svg-jar": "^1.2.2",
     "ember-test-selectors": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,14 +5174,7 @@ ember-in-element-polyfill@^0.1.2:
     ember-cli-version-checker "^2.1.0"
     ember-wormhole "^0.5.4"
 
-ember-in-viewport@~3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ember-in-viewport/-/ember-in-viewport-3.0.3.tgz#49c60b52525795246761742ed4495ad6cd9bf70d"
-  integrity sha512-Iw8qquApABdrP9xA8hJFaYAxz/iOGLJ0Acq4QptemEnpsHcQqAET/SKL/A1fbtDGQAVtB5+bULaJcsrzRMCteg==
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
-ember-inflector@^2.0.1:
+ember-inflector@^2.0.0, ember-inflector@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.1.0.tgz#afcb92d022a4eab58f08ff4578eafc3a1de2d09b"
   dependencies:
@@ -5375,15 +5368,6 @@ ember-source@~3.4.0:
     inflection "^1.12.0"
     jquery "^3.3.1"
     resolve "^1.6.0"
-
-ember-sticky-element@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ember-sticky-element/-/ember-sticky-element-0.2.3.tgz#39702e0fc0f04905a7b34add61a85a9186d3d16b"
-  integrity sha512-AtKkM8zh6LK5FsPxtsDywUSodGk5c2AI03vcgk995dC5Z7DG4XLJoAwV0FZM5RYnymnYEJvOs6VTcIM8uwcX5w==
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-htmlbars "^2.0.1"
-    ember-in-viewport "~3.0.0"
 
 ember-styleguide@^2.3.1:
   version "2.5.0"


### PR DESCRIPTION
This reverts commit f885e7622fc81d2c469e334a5a6ea14c668449ed.
There are problems with scroll to header that the sticky header feature introduces (see https://github.com/kaliber5/ember-sticky-element/issues/38) . Reverting until resolved