### PR TITLE
fix broken ember data index page #635

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -42,11 +42,10 @@ export default Route.extend({
       // if there is no class, module, or namespace specified...
       let latestVersion = getLastVersion(model.get('project.projectVersions'));
       let isLatestVersion = transitionVersion === latestVersion || transitionVersion === 'release';
-      let isEmberProject = model.get('project.id') === 'ember';
       let shouldConvertPackages = semverCompare(model.get('version'), '2.16') < 0;
-      if ((!shouldConvertPackages || isLatestVersion) && isEmberProject) {
-        // ... and the transition version is the latest release, and the selected docs are
-        // ember (not Ember Data), then show the landing page
+      if (!shouldConvertPackages || isLatestVersion) {
+        // ... and the transition version is the latest release,
+        // display the landing page at 
         return this.transitionTo('project-version.index');
       } else {
         // else go to the version specified

--- a/app/templates/project-version/index.hbs
+++ b/app/templates/project-version/index.hbs
@@ -1,5 +1,5 @@
 <article class="chapter">
-  <h1>Ember.js API Documentation</h1>
+  <h1>Ember API Documentation</h1>
   <p>
     To get started, choose a project (Ember or Ember Data) and a version 
     from the dropdown menu. Ember has core methods used in any app, while Ember Data has 

--- a/tests/acceptance/redirects-test.js
+++ b/tests/acceptance/redirects-test.js
@@ -12,17 +12,17 @@ module('Acceptance | redirects', function(hooks) {
       `/ember/release`,
       'routes to the latest version of the project'
     );
-    assert.dom('h1').hasText('Ember.js API Documentation');
+    assert.dom('h1').hasText('Ember API Documentation');
   });
 
   test('visiting /ember-data', async function (assert) {
     await visit('/ember-data');
     assert.equal(
       currentURL(),
-      `/ember-data/release/modules/ember-data`,
-      'routes to the first page of ember data'
+      `/ember-data/release`,
+      'routes to the landing page'
     );
-    assert.dom('h1').hasText('Package ember-data');
+    assert.dom('h1').hasText('Ember API Documentation');
   });
 
   test('visiting pre-2.16 version', async function(assert) {


### PR DESCRIPTION
Closes #635 

This is a hotfix to get things minimally working again. We need to create an Ember Data specific landing page after this.