### PR TITLE
[BUGFIX] fix ember-data source links for v3.11+

### DIFF
--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -1,11 +1,11 @@
 import { helper } from '@ember/component/helper';
-import githubMap from '../utils/github-map';
+import githubMap, { mainDir } from '../utils/github-map';
 
 export function githubLink([project, version, file, line], { isEdit=false }) {
   if (isEdit) {
-    return `https://github.com/${githubMap[project]}/edit/release/${file}#L${line}`;
+    return `https://github.com/${githubMap[project]}/edit/release${mainDir(project, version)}${file}#L${line}`;
   }
-  return `https://github.com/${githubMap[project]}/tree/v${version}/${file}#L${line}`;
+  return `https://github.com/${githubMap[project]}/tree/v${version}${mainDir(project, version)}${file}#L${line}`;
 }
 
 export default helper(githubLink);

--- a/app/utils/github-map.js
+++ b/app/utils/github-map.js
@@ -1,3 +1,17 @@
+import semverCompare from 'semver-compare';
+
+export const mainDir = function(project, version) {
+  if (project === 'ember') {
+    return '/';
+  }
+  if (project === 'ember-data') {
+    if (semverCompare(version, '3.11') === -1) {
+      return '/';
+    }
+    return '/packages/-ember-data/';
+  }
+};
+
 export default {
   'ember': 'emberjs/ember.js',
   'ember-data': 'emberjs/data'


### PR DESCRIPTION
Combined with https://github.com/emberjs/data/pull/6449 , this should fix links to source files for ember data v3.11+ (following conversion to packages).

cc @runspired @sivakumar-kailasam 