### PR TITLE
Include support for @glimmer packages

### DIFF
--- a/app/routes/project-version/modules/module.js
+++ b/app/routes/project-version/modules/module.js
@@ -10,7 +10,7 @@ export default ClassRoute.extend(ScrollTracker, {
     let compactVersion = transition.params['project-version'].project_version;
     let projectVersion = getFullVersion(compactVersion, projectID, projectObj, this.metaStore);
     let klass = params['module'];
-    if (!~klass.indexOf(projectID) && klass !== 'rsvp' && klass !== 'jquery') {
+    if (!~klass.indexOf(projectID) && klass !== 'rsvp' && klass !== 'jquery' && klass !== '@glimmer/component' && klass !== '@glimmer/tracking') {
       klass = `${projectID}-${klass}`;
     }
     return this.find('module', `${projectID}-${projectVersion}-${klass}`);


### PR DESCRIPTION
Now that some packages in the TOC can have `@glimmer` in the name, we need to adjust our URL filtering and creation.

Without this, any docs with `@module @glimmer/component` (for example) will be 404s.
