### PR TITLE
yarn test should return non-zero exit code if tests fail in CI

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -18,7 +18,10 @@ const execEmberProcess = async (cmd) => {
   let proc = spawn(ember, [cmd]);
   hookupLoggers(proc);
   try {
-    await proc;
+    let { code } = await proc;
+    if (code !== 0) {
+      throw Error();
+    }
   } catch (e) {
     return process.exit(1);
   }


### PR DESCRIPTION
On master, `yarn test` returns a zero exit code (and github shows a check mark) even if tests fail in CI.

This PR will not pass until #647 is merged.