### PR TITLE
Remove bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,9 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add bower
 
 install:
   - yarn install
-  - bower install
 
 script:
   - yarn test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,10 @@ clone the latest ember.js api docs from github
 cd to the cloned ember-api-docs directory
  - cd ember-api-docs
 
-ensure Node.js, bower and yarn are installed
+ensure Node.js and yarn are installed
 
 follow these commands to build ember.js
  - yarn install
- - bower install
  - yarn run build
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "ember-api-docs",
-  "dependencies": {
-    "bitters": "^1.5.0",
-    "neat": "^1.8.0"
-  }
-}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,8 +13,7 @@ module.exports = function(defaults) {
     sassOptions: {
       includePaths: [
         'app/styles',
-        'bower_components/neat/app/assets/stylesheets',
-        'bower_components/bitters/core',
+        'node_modules/bourbon-neat/app/assets/stylesheets',
         'node_modules/normalize.css'
       ]
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "algoliasearch": "^3.32.1",
+    "bourbon-neat": "^1.9.1",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,6 +2327,13 @@ bootstrap@^4.1.3:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.3.tgz#0eb371af2c8448e8c210411d0cb824a6409a12be"
   integrity sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w==
 
+bourbon-neat@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/bourbon-neat/-/bourbon-neat-1.9.1.tgz#f7932e889bb24ac908c45d399b04bd5b0df1e949"
+  integrity sha512-W4gjJx1j+KPNF8Bg/3ecaTHPMC7IJ2pFKmYEZanWtzFk9MpM9kn+f14iXypIj8htHMRmzVByhzFhVWwuDKSTYg==
+  dependencies:
+    node-sass "^4.1.1"
+
 bourbon@5.1.0, bourbon@^5.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-5.1.0.tgz#84fa10de4c4e837602d8c2ec716d74bcb8915bad"
@@ -8645,6 +8652,11 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -9164,6 +9176,11 @@ nan@^2.10.0, nan@^2.9.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nanomatch@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
@@ -9330,6 +9347,29 @@ node-releases@^1.0.5:
   integrity sha512-+qV91QMDBvARuPxUEfI/mRF/BY+UAkTIn3pvmvM2iOLIRvv6RNYklFXBgrkky6P1wXUqQW1P3qKlWxxy4JZbfg==
   dependencies:
     semver "^5.3.0"
+
+node-sass@^4.1.1:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
+  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
 
 node-sass@^4.9.4:
   version "4.10.0"


### PR DESCRIPTION
- Replaces bower "neat" package with the npm "bourbon-neat" package
- Removes "bitters" because it was only used for generating [this file](https://github.com/ember-learn/ember-api-docs/blob/38128584527a6f79cfb90801f55a043696a23a1a/app/styles/base/_base.scss) and [this folder](https://github.com/ember-learn/ember-api-docs/tree/38128584527a6f79cfb90801f55a043696a23a1a/app/styles/base) which are checked in. For more information, see [this issue](https://github.com/thoughtbot/bitters/pull/30)
- Removes all use of bower