### PR TITLE
fix links from ember-data to ember

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
         'lib/**/*.js',
         'bin/*',
       ],
+      excludedFiles: ['config/deprecation-workflow.js'],
       parserOptions: {
         sourceType: 'script',
         ecmaVersion: 2017

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ install:
   - yarn install
 
 script:
+  - yarn lint:js
   - yarn test

--- a/app/models/class.js
+++ b/app/models/class.js
@@ -53,6 +53,23 @@ export default DS.Model.extend({
   extendedClassProjectName: projectNameFromClassName('extends'),
   extendedClassVersion: guessVersionFor('extends'),
   usedClassProjectName: projectNameFromClassName('uses'),
-  usedClassVersion: guessVersionFor('uses')
+  usedClassVersion: guessVersionFor('uses'),
+
+  extendedClassShortName: computed('extends', function() {
+    let extendedClassName = this.get('extends');
+    if (extendedClassName.substr(0, 6) === 'Ember.') {
+      return extendedClassName.substr(6);
+    }
+    return extendedClassName;
+  }),
+
+  usesObjects: computed('uses', function() {
+    return this.get('uses').map(className => ({
+      name: className,
+      shortName: className.substr(0, 6) === 'Ember.' ? className.substr(6) : className,
+      projectId: className.substr(0, 6) === 'Ember.' ? 'ember' :
+        className.substr(0, 3) === 'DS' ? 'ember-data' : this.get('project.id')
+    }));
+  })
 
 });

--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -9,16 +9,16 @@
     {{#if model.extends}}
       <div class="attribute">
         <span class="attribute-label">Extends:</span>
-        <span class="attribute-value">{{#link-to 'project-version.classes.class' model.extendedClassProjectName model.projectVersion.compactVersion model.extends}}{{model.extends}}{{/link-to}}</span>
+        <span class="attribute-value">{{#link-to data-test-extends-link 'project-version.classes.class' model.extendedClassProjectName model.projectVersion.compactVersion model.extendedClassShortName}}{{model.extends}}{{/link-to}}</span>
       </div>
     {{/if}}
     {{#if model.uses}}
       <div class="attribute">
         <span class="attribute-label">Uses:</span>
         <span class="attribute-value">
-          {{#each model.uses as |parentClass idx|}}
+          {{#each model.usesObjects as |parentClass idx|}}
             {{#if (not-eq idx 0)}}<span class="comma">,</span>{{/if}}
-            {{#link-to 'project-version.classes.class' model.usedClassProjectName model.projectVersion.compactVersion parentClass}}{{parentClass}}{{/link-to}}
+            {{#link-to data-test-uses-link 'project-version.classes.class' parentClass.projectId model.projectVersion.compactVersion parentClass.shortName}}{{parentClass.name}}{{/link-to}}
           {{/each}}
         </span>
       </div>

--- a/tests/acceptance/link-from-ember-data-to-ember-test.js
+++ b/tests/acceptance/link-from-ember-data-to-ember-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, click, currentURL, settled } from '@ember/test-helpers';
+import { timeout } from 'ember-concurrency';
+
+module('Acceptance | link from ember data to ember test', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('extends link test', async function (assert) {
+    await visit('/ember-data/3.14/classes/Errors');
+    await click('[data-test-extends-link]');
+    await settled();
+    await timeout(10);
+    await settled();
+    assert.equal(currentURL(), '/ember/3.14/classes/ArrayProxy');
+  });
+
+  test('uses link test', async function (assert) {
+    await visit('/ember-data/3.14/classes/Errors');
+    await click('[data-test-uses-link]');
+    await settled();
+    await timeout(10);
+    await settled();
+    assert.equal(currentURL(), '/ember/3.14/classes/Evented');
+  });
+});


### PR DESCRIPTION
This is another redirect to fix links from Ember Data to Ember for `Extends` and `Uses` classes. This does not fix inherited items not showing up.

For #622 