### PR TITLE
silence deprecations to shorten log length

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -1,9 +1,8 @@
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
   workflow: [
-    { handler: "throw", matchId: "ember-env.old-extend-prototypes" },
-    { handler: "throw", matchId: "ember-routing.route-router" },
-    { handler: "throw", matchId: "ember-runtime.deprecate-copy-copyable" },
-    { handler: "throw", matchId: "ember-console.deprecate-logger" }
+    { handler: "silence", matchId: "transition-state" },
+    { handler: "silence", matchId: "deprecate-router-events" },
+    { handler: "silence", matchId: "ember-native-dom-helpers-click" }
   ]
 };


### PR DESCRIPTION
Travis is failing on master because log length is too long.