### PR TITLE
fix async request leaks in fastboot

### DIFF
--- a/app/helpers/is-latest.js
+++ b/app/helpers/is-latest.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 import getLastVersion from 'ember-api-docs/utils/get-last-version';
 
 export function isLatest(params, { version, allVersions}) {
-  let latestVersion = getLastVersion(allVersions);
+  let latestVersion = getLastVersion(allVersions.map(version => version.id));
   return version === latestVersion;
 }
 

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -31,7 +31,7 @@ export default Route.extend({
     return this.store.findRecord('project-version', id, { includes: 'project' });
   },
 
-  // Using redirect instead of afterModel so transition succeeds and returns 30
+  // Using redirect instead of afterModel so transition succeeds and returns 307
   redirect(model, transition) {
     this._gatherHeadDataFromVersion(model, transition.params['project-version'].project_version);
     let classParams = transition.params['project-version.classes.class'];
@@ -41,7 +41,7 @@ export default Route.extend({
     let transitionVersion = this.projectService.getUrlVersion();
     if (!classParams && !moduleParams && !namespaceParams && !functionParams) {
       // if there is no class, module, or namespace specified...
-      let latestVersion = getLastVersion(model.get('project.projectVersions'));
+      let latestVersion = getLastVersion(model.get('project.content').hasMany('projectVersions').ids());
       let isLatestVersion = transitionVersion === latestVersion || transitionVersion === 'release';
       let shouldConvertPackages = semverCompare(model.get('version'), '2.16') < 0;
       if (!shouldConvertPackages || isLatestVersion) {

--- a/app/utils/get-full-version.js
+++ b/app/utils/get-full-version.js
@@ -4,7 +4,7 @@ import getLastVersion from 'ember-api-docs/utils/get-last-version';
 export default function getFullVersion(urlVersion, project, projectObj, metaStore) {
   let projectVersion;
   if (urlVersion === 'release') {
-    let versions = projectObj.get('projectVersions').toArray();
+    let versions = projectObj.hasMany('projectVersions').ids();
     projectVersion = metaStore.getFullVersion(project, getCompactVersion(getLastVersion(versions)));
   } else {
     projectVersion = metaStore.getFullVersion(project, urlVersion);

--- a/app/utils/get-last-version.js
+++ b/app/utils/get-last-version.js
@@ -1,7 +1,7 @@
 import semverCompare from 'semver-compare';
 
 export default function getLastVersion(projectVersions) {
-  const sortedVersions = projectVersions.getEach('id').map(v => v.replace(/ember-data-|ember-/g, '')).sort((v1, v2) => {
+  const sortedVersions = projectVersions.map(v => v.replace(/ember-data-|ember-/g, '')).sort((v1, v2) => {
     return semverCompare(v1, v2);
   });
   return sortedVersions[sortedVersions.length - 1];

--- a/tests/unit/utils/get-full-version-test.js
+++ b/tests/unit/utils/get-full-version-test.js
@@ -1,9 +1,10 @@
 import getFullVersion from 'ember-api-docs/utils/get-full-version';
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-import Object from '@ember/object';
-import ArrayProxy from '@ember/array/proxy';
 import { A } from '@ember/array';
+import DS from 'ember-data';
+
+const { ManyArray } = DS;
 
 module('Unit | Utility | get full version', function() {
   test('should return full version when release', function(assert) {
@@ -14,10 +15,18 @@ module('Unit | Utility | get full version', function() {
         return '2.17.1';
       }
     });
-    let projectVersions = ArrayProxy.create({
-      content: A([{ id: 'ember-2.17.1'}, { id: 'ember-2.16.1' }])
+    let projectVersions = ManyArray.create({
+      content: A([{ id: 'ember-2.17.1'}, { id: 'ember-2.16.1' }]),
+      flushCanonical() {},
+      ids() {
+        return this.content.map(obj => obj.id);
+      }
     });
-    let projectObj = Object.create({ projectVersions });
+    let projectObj = {
+      hasMany() {
+        return projectVersions;
+      }
+    };
     let result = getFullVersion('release', 'ember', projectObj, metaStore);
     assert.equal(result, '2.17.1');
   });

--- a/tests/unit/utils/get-full-version-test.js
+++ b/tests/unit/utils/get-full-version-test.js
@@ -15,6 +15,10 @@ module('Unit | Utility | get full version', function() {
         return '2.17.1';
       }
     });
+
+    // mock the project object hasMany relationship
+    // hasMany('projectVersions') returns a DS.ManyArray
+    // and getFullVersion() calls ids() on it
     let projectVersions = ManyArray.create({
       content: A([{ id: 'ember-2.17.1'}, { id: 'ember-2.16.1' }]),
       flushCanonical() {},
@@ -27,6 +31,7 @@ module('Unit | Utility | get full version', function() {
         return projectVersions;
       }
     };
+
     let result = getFullVersion('release', 'ember', projectObj, metaStore);
     assert.equal(result, '2.17.1');
   });

--- a/tests/unit/utils/get-last-version-test.js
+++ b/tests/unit/utils/get-last-version-test.js
@@ -5,9 +5,9 @@ import { module, test } from 'qunit';
 module('Unit | Utility | get-latest-version', function() {
   test('should pick the latest version of ember', function (assert) {
     let versions = A([
-      { id: 'ember-1.13.0' },
-      { id: 'ember-2.7' },
-      { id: 'ember-2.1.10' }
+      'ember-1.13.0',
+      'ember-2.7',
+      'ember-2.1.10'
     ]);
     let latestVersion = getLastVersion(versions);
     assert.equal(latestVersion, '2.7');
@@ -15,9 +15,9 @@ module('Unit | Utility | get-latest-version', function() {
 
   test('should pick the latest version of ember-data', function (assert) {
     let versions = A([
-      { id: 'ember-data-1.13.0' },
-      { id: 'ember-data-2.7' },
-      { id: 'ember-data-2.1.10' }
+      'ember-data-1.13.0',
+      'ember-data-2.7',
+      'ember-data-2.1.10'
     ]);
     let latestVersion = getLastVersion(versions);
     assert.equal(latestVersion, '2.7');


### PR DESCRIPTION
Getting version ids should not require fetching all versions asynchronously. This prevents that and incidentally prevents async request leaks in fastboot, which I was originally trying to fix.

Thanks to @kiwiupover for all the help today!