### PR TITLE
Fix link in top nav dropdown

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import config from 'ember-api-docs/config/environment';
 
 const links = [
   {
@@ -12,7 +11,7 @@ const links = [
         type: 'link'
       },
       {
-        href: config.APP.domain,
+        href: 'https://api.emberjs.com/ember/release',
         name: 'API Reference',
         type: 'link'
       },


### PR DESCRIPTION
Was reported as bug in Discord

I don't see an issue with hardcoding it here, if there's context I'm missing, please let me know

WAS:
![api-docs-was](https://user-images.githubusercontent.com/1372946/85798940-3cb4a000-b6f3-11ea-8320-68bbf016115a.gif)

IS:
![api-docs](https://user-images.githubusercontent.com/1372946/85798949-4211ea80-b6f3-11ea-832c-92000e3b5340.gif)
