### PR TITLE
Update a redirect for ember data legacy modules (#735)

### DIFF
--- a/app/routes/data-module.js
+++ b/app/routes/data-module.js
@@ -22,10 +22,16 @@ export default Route.extend({
       moduleName = '@' + moduleName;
     }
     let mappingInfo = this.legacyModuleMappings.getNewModuleFromOld(moduleName, mappings);
-    return this.transitionTo(`project-version.modules.module`,
-      'ember-data',
-      'release',
-      mappingInfo.module);
+    if(mappingInfo.module === '@ember-data') {
+      return this.transitionTo(`project-version`,
+        'ember-data',
+        'release');
+    } else {
+      return this.transitionTo(`project-version.modules.module`,
+        'ember-data',
+        'release',
+        mappingInfo.module);
+    }
   }
 
 });

--- a/tests/acceptance/convert-legacy-url-to-current-test.js
+++ b/tests/acceptance/convert-legacy-url-to-current-test.js
@@ -25,9 +25,9 @@ module('Acceptance | convert legacy url to current', function(hooks) {
     assert.equal(currentURL(), '/ember/release/modules/@ember%2Fapplication');
   });
 
-  test('should convert url for legacy ember data module to 404', async function (assert) {
+  test('should convert url for legacy ember data module to index', async function (assert) {
     await visit('/data/modules/ember-data.html');
-    assert.equal(currentURL(), '/404');
+    assert.equal(currentURL(), '/ember-data/release');
   });
 
   test('should convert unknown legacy modules url to landing page', async function (assert) {


### PR DESCRIPTION
Updated `data-modules.js` to redirect if its `@ember-data` and fix a test too.