### PR TITLE
Disable ligatures in code blocks

### DIFF
--- a/app/styles/components/_highlight.scss
+++ b/app/styles/components/_highlight.scss
@@ -8,6 +8,7 @@
   margin: $small-spacing 0 $large-spacing;
   overflow: hidden;
   position: relative;
+  font-variant-ligatures: none;
 
   &.handlebars {
     .inline,


### PR DESCRIPTION
Before:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/9835/107673488-e6c54600-6c4a-11eb-9336-9df246d5fc22.png">
After:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/9835/107673506-ecbb2700-6c4a-11eb-82b3-b293e7d44df9.png">

See the `fi` in `fish` and `firstObject`.