### PR TITLE
Create Ember Data landing page (#638)

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -50,10 +50,11 @@ export default Route.extend({
       // if there is no class, module, or namespace specified...
       let latestVersion = getLastVersion(model.get('project.content').hasMany('projectVersions').ids());
       let isLatestVersion = transitionVersion === latestVersion || transitionVersion === 'release';
+      let isEmberProject = model.get('project.id') === 'ember';
       let shouldConvertPackages = semverCompare(model.get('version'), '2.16') < 0;
-      if (!shouldConvertPackages || isLatestVersion) {
-        // ... and the transition version is the latest release,
-        // display the landing page at
+      if ((!shouldConvertPackages || isLatestVersion) && isEmberProject) {
+        // ... and the transition version is the latest release, and the selected docs are
+        // ember (not Ember Data), then display the landing page at
         return this.transitionTo('project-version.index');
       } else {
         // else go to the version specified

--- a/app/templates/ember-data.hbs
+++ b/app/templates/ember-data.hbs
@@ -1,0 +1,56 @@
+<article class="chapter">
+  <h1>
+    Ember Data API Documentation
+  </h1>
+  <p>
+    Ember Data is a library for robustly managing data in applications built with Ember.js.
+  </p>
+  <h2>
+    Commonly searched-for documentation
+  </h2>
+  <ul class="spec-method-list">
+    <li>
+      {{#link-to "project-version.classes.class" "Model"}}
+        Model
+      {{/link-to}}
+      - an object that represents the underlying data that your application presents to the user.
+    </li>
+    <li>
+      {{#link-to "project-version.classes.class" "Store"}}
+        Store
+      {{/link-to}}
+      - a service that contains all of the data for records loaded from the server.
+    </li>
+    <li>
+      {{#link-to "project-version.classes.class" "Adapter"}}
+        Adapter
+      {{/link-to}}
+      - determines how data is persisted to a backend data store.
+    </li>
+    <li>
+      {{#link-to "project-version.classes.class" "Serializer"}}
+        Serializer
+      {{/link-to}}
+      - format the data sent to and received from the backend store.
+    </li>
+  </ul>
+  <h2>
+    Useful links
+  </h2>
+  <ul>
+    <li>
+      <h5>
+        <a href="https://github.com/ember-learn/ember-api-docs">
+          API Documentation Github Repository
+        </a>
+      </h5>
+    </li>
+    <li>
+      <h5>
+        <a href="https://guides.emberjs.com/release/models/">
+          Introduction to Ember Data
+        </a>
+      </h5>
+    </li>
+  </ul>
+</article>

--- a/tests/acceptance/redirects-test.js
+++ b/tests/acceptance/redirects-test.js
@@ -15,16 +15,6 @@ module('Acceptance | redirects', function(hooks) {
     assert.dom('h1').hasText('Ember API Documentation');
   });
 
-  test('visiting /ember-data', async function (assert) {
-    await visit('/ember-data');
-    assert.equal(
-      currentURL(),
-      `/ember-data/release`,
-      'routes to the landing page'
-    );
-    assert.dom('h1').hasText('Ember API Documentation');
-  });
-
   test('visiting pre-2.16 version', async function(assert) {
     await visit('/ember/1.0');
 


### PR DESCRIPTION
Closes #638 

Create a draft ember data landing page that has a list of commonly-searched-for documentation for Ember Data (models, store, adapters and serializers).