### PR TITLE
Support more glimmer segments

### DIFF
--- a/app/routes/project-version/modules/module.js
+++ b/app/routes/project-version/modules/module.js
@@ -11,9 +11,12 @@ export default ClassRoute.extend(ScrollTracker, {
     let projectVersion = getFullVersion(compactVersion, project, projectObj, this.metaStore);
     let klass = params['module'];
 
+    // These modules should not have `ember-` tacked onto the front of them
+    // when forming the ids and URLs.
+    let isNotEmber = klass.match(/@glimmer|rsvp|jquery/)
+
     if (
-      !~klass.indexOf(project) &&
-      !['rsvp', 'jquery', '@glimmer/component', '@glimmer/tracking'].includes(klass)
+      !~klass.indexOf(project) && !isNotEmber
     ) {
       klass = `${project}-${klass}`;
     }


### PR DESCRIPTION
Previously, @glimmer/tracking/primitives/cache was a 404. This was
because the id parsing was adding an extra "ember-" to the front of
the id.

Closes #751

Co-authored-by: Amy Lam <amyrlam@users.noreply.github.com>