### PR TITLE
ember-data landing page: use ember-data-overview module main if present

### DIFF
--- a/app/components/ember-data-landing-page.hbs
+++ b/app/components/ember-data-landing-page.hbs
@@ -1,4 +1,4 @@
-<article class="chapter">
+<<article class="chapter">
   <h1>
     Ember Data API Documentation
   </h1>

--- a/app/components/ember-landing-page.hbs
+++ b/app/components/ember-landing-page.hbs
@@ -1,0 +1,39 @@
+<article class="chapter">
+  <h1>Ember API Documentation</h1>
+  <p>
+    To get started, choose a project (Ember or Ember Data) and a version 
+    from the dropdown menu. Ember has core methods used in any app, while Ember Data has 
+    documentation of the built-in library for making requests to a back end.
+    If you're looking for documentation of the command line tool used to generate files, build your 
+    app, and more, visit <a href="https://cli.emberjs.com/">ember-cli</a>. The latest
+    testing API is available at 
+    <a href="https://github.com/emberjs/ember-test-helpers/blob/master/API.md">ember-test-helpers</a>.
+  </p>
+  <h2>Commonly searched-for documentation</h2>
+  <ul class="spec-method-list">
+    <li>Components - {{#link-to 'project-version.classes.class' 'Component'}}Classic{{/link-to}} or {{#link-to 'project-version.modules.module' '@glimmer/component'}}Glimmer{{/link-to}}; a view that is completely isolated</li>
+    <li>{{#link-to 'project-version.functions.function' '@glimmer/tracking' 'tracked'}}Tracked{{/link-to}} - make your templates responsive to property updates</li>
+    <li>{{#link-to 'project-version.classes.class' 'ComputedProperty'}}Computed Properties{{/link-to}} - declare functions as properties</li>
+    <li>{{#link-to 'project-version.classes.class' '@ember/object/computed'}}Computed Macros{{/link-to}} - shorter ways of expressing certain types of computed properties</li>
+    <li>{{#link-to 'project-version.classes.class' 'EmberArray'}}EmberArray{{/link-to}} - contains methods like {{#link-to 'project-version.classes.class.methods.method' 'EmberArray' 'forEach' (query-params anchor='forEach')}}forEach{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'EmberArray' 'mapBy' (query-params anchor='mapBy')}}mapBy{{/link-to}} that help you iterate over Ember Objects</li>
+    <li>{{#link-to 'project-version.classes.class' 'EmberObject'}}EmberObject{{/link-to}} - the main base class for all Ember objects, including the {{#link-to 'project-version.classes.class.methods.method' 'EmberObject' 'get' (query-params anchor='get')}}get{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'EmberObject' 'set' (query-params anchor='set')}}set{{/link-to}} methods</li>
+    <li>{{#link-to 'project-version.classes.class' 'Ember.Templates.helpers'}}Ember.Templates.helpers{{/link-to}} - built-in functions that can be used in templates, such as the {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'each' (query-params anchor='each')}}each{{/link-to}} helper</li>
+    <li>{{#link-to 'project-version.classes.class' 'Ember.Templates.helpers'}}Ember.Templates.helpers{{/link-to}} - built-in functions that can be used in templates, such as the {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'each' (query-params anchor='each')}}each{{/link-to}}, {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'on' (query-params anchor='on')}}on{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'fn' (query-params anchor='fn')}}fn{{/link-to}} helpers</li>
+    <li>{{#link-to 'project-version.classes.class' 'Helper'}}Helpers{{/link-to}} - a way to define custom display functions that are used in templates</li>
+    <li>{{#link-to 'project-version.classes.class' 'Route'}}Route{{/link-to}} - used to define individual routes, including the {{#link-to 'project-version.classes.class.methods.method' 'Route' 'model' (query-params anchor='model')}}model{{/link-to}} hook for loading data</li>
+    <li>{{#link-to 'project-version.classes.class' 'Service'}}Service{{/link-to}} - an Ember object that lives for the duration of the application, and can be made available in different parts of your application</li>
+  </ul>
+  <h2>Useful links</h2>
+  <ul>
+    <li>
+      <h5>
+        <a href="https://github.com/ember-learn/ember-api-docs">API Documentation Github Repository</a>
+      </h5>
+    </li>
+    <li>
+      <h5>
+        <a href="https://guides.emberjs.com/release/getting-started/core-concepts/">Ember Core Concepts</a>
+      </h5>
+    </li>
+  </ul>
+</article>

--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -44,7 +44,8 @@ export default Controller.extend({
 
   getModuleRelationships(versionId, moduleType) {
     let relations = this.getRelations(moduleType);
-    return relations.map(id => id.substring(versionId.length + 1))
+    // filter overviews out. If other projects add their overview we should filter those too.
+    return relations.map(id => id.substring(versionId.length + 1)).filter(id => id !== 'ember-data-overview');
   },
 
   getRelations(relationship) {

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -50,10 +50,11 @@ export default Route.extend({
       // if there is no class, module, or namespace specified...
       let latestVersion = getLastVersion(model.get('project.content').hasMany('projectVersions').ids());
       let isLatestVersion = transitionVersion === latestVersion || transitionVersion === 'release';
+      let isEmberProject = model.get('project.id') === 'ember';
       let shouldConvertPackages = semverCompare(model.get('version'), '2.16') < 0;
-      if (!shouldConvertPackages || isLatestVersion) {
-        // ... and the transition version is the latest release,
-        // display the landing page at
+      if ((!shouldConvertPackages || isLatestVersion) && isEmberProject) {
+        // ... and the transition version is the latest release, and the selected docs are
+        // ember (not Ember Data), then display the landing page at
         return this.transitionTo('project-version.index');
       } else {
         // else go to the version specified

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -54,6 +54,15 @@ export default Route.extend({
       if (!shouldConvertPackages || isLatestVersion) {
         // ... and the transition version is the latest release,
         // display the landing page at
+
+        // ember-data if @main declaration exists for ember-data-overview
+        let versionId = model.get('id');
+        let modules = model.hasMany('modules').ids().map(id => id.substring(versionId.length + 1));
+        if (model.get('project.id') === 'ember-data' && modules.indexOf('ember-data-overview') !== -1) {
+          return this.transitionTo('project-version.modules.module', model.get('project.id'), transitionVersion, 'ember-data-overview');
+        }
+
+        // ember / ember-cli / ember-data if no @main declaration exists for ember-data-overview
         return this.transitionTo('project-version.index');
       } else {
         // else go to the version specified

--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -50,11 +50,10 @@ export default Route.extend({
       // if there is no class, module, or namespace specified...
       let latestVersion = getLastVersion(model.get('project.content').hasMany('projectVersions').ids());
       let isLatestVersion = transitionVersion === latestVersion || transitionVersion === 'release';
-      let isEmberProject = model.get('project.id') === 'ember';
       let shouldConvertPackages = semverCompare(model.get('version'), '2.16') < 0;
-      if ((!shouldConvertPackages || isLatestVersion) && isEmberProject) {
-        // ... and the transition version is the latest release, and the selected docs are
-        // ember (not Ember Data), then display the landing page at
+      if (!shouldConvertPackages || isLatestVersion) {
+        // ... and the transition version is the latest release,
+        // display the landing page at
         return this.transitionTo('project-version.index');
       } else {
         // else go to the version specified

--- a/app/routes/project-version/index.js
+++ b/app/routes/project-version/index.js
@@ -1,4 +1,9 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
+    async model() {
+        const projectVersion = this.modelFor('project-version');
+        const project = await projectVersion.project;
+        return project;
+    }
 });

--- a/app/templates/ember-data.hbs
+++ b/app/templates/ember-data.hbs
@@ -1,0 +1,56 @@
+<article class="chapter">
+  <h1>
+    Ember Data API Documentation
+  </h1>
+  <p>
+    Ember Data is a library for robustly managing data in applications built with Ember.js.
+  </p>
+  <h2>
+    Commonly searched-for documentation
+  </h2>
+  <ul class="spec-method-list">
+    <li>
+      {{#link-to "project-version.classes.class" "Model"}}
+        Model
+      {{/link-to}}
+      - an object that represents the underlying data that your application presents to the user.
+    </li>
+    <li>
+      {{#link-to "project-version.classes.class" "Store"}}
+        Store
+      {{/link-to}}
+      - a service that contains all of the data for records loaded from the server.
+    </li>
+    <li>
+      {{#link-to "project-version.classes.class" "Adapter"}}
+        Adapter
+      {{/link-to}}
+      - determines how data is persisted to a backend data store.
+    </li>
+    <li>
+      {{#link-to "project-version.classes.class" "Serializer"}}
+        Serializer
+      {{/link-to}}
+      - format the data sent to and received from the backend store.
+    </li>
+  </ul>
+  <h2>
+    Useful links
+  </h2>
+  <ul>
+    <li>
+      <h5>
+        <a href="https://github.com/ember-learn/ember-api-docs">
+          API Documentation Github Repository
+        </a>
+      </h5>
+    </li>
+    <li>
+      <h5>
+        <a href="https://guides.emberjs.com/release/models/">
+          Introduction to Ember Data
+        </a>
+      </h5>
+    </li>
+  </ul>
+</article>

--- a/app/templates/project-version/index.hbs
+++ b/app/templates/project-version/index.hbs
@@ -1,39 +1,5 @@
-<article class="chapter">
-  <h1>Ember API Documentation</h1>
-  <p>
-    To get started, choose a project (Ember or Ember Data) and a version 
-    from the dropdown menu. Ember has core methods used in any app, while Ember Data has 
-    documentation of the built-in library for making requests to a back end.
-    If you're looking for documentation of the command line tool used to generate files, build your 
-    app, and more, visit <a href="https://cli.emberjs.com/">ember-cli</a>. The latest
-    testing API is available at 
-    <a href="https://github.com/emberjs/ember-test-helpers/blob/master/API.md">ember-test-helpers</a>.
-  </p>
-  <h2>Commonly searched-for documentation</h2>
-  <ul class="spec-method-list">
-    <li>Components - {{#link-to 'project-version.classes.class' 'Component'}}Classic{{/link-to}} or {{#link-to 'project-version.modules.module' '@glimmer/component'}}Glimmer{{/link-to}}; a view that is completely isolated</li>
-    <li>{{#link-to 'project-version.functions.function' '@glimmer/tracking' 'tracked'}}Tracked{{/link-to}} - make your templates responsive to property updates</li>
-    <li>{{#link-to 'project-version.classes.class' 'ComputedProperty'}}Computed Properties{{/link-to}} - declare functions as properties</li>
-    <li>{{#link-to 'project-version.classes.class' '@ember/object/computed'}}Computed Macros{{/link-to}} - shorter ways of expressing certain types of computed properties</li>
-    <li>{{#link-to 'project-version.classes.class' 'EmberArray'}}EmberArray{{/link-to}} - contains methods like {{#link-to 'project-version.classes.class.methods.method' 'EmberArray' 'forEach' (query-params anchor='forEach')}}forEach{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'EmberArray' 'mapBy' (query-params anchor='mapBy')}}mapBy{{/link-to}} that help you iterate over Ember Objects</li>
-    <li>{{#link-to 'project-version.classes.class' 'EmberObject'}}EmberObject{{/link-to}} - the main base class for all Ember objects, including the {{#link-to 'project-version.classes.class.methods.method' 'EmberObject' 'get' (query-params anchor='get')}}get{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'EmberObject' 'set' (query-params anchor='set')}}set{{/link-to}} methods</li>
-    <li>{{#link-to 'project-version.classes.class' 'Ember.Templates.helpers'}}Ember.Templates.helpers{{/link-to}} - built-in functions that can be used in templates, such as the {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'each' (query-params anchor='each')}}each{{/link-to}} helper</li>
-    <li>{{#link-to 'project-version.classes.class' 'Ember.Templates.helpers'}}Ember.Templates.helpers{{/link-to}} - built-in functions that can be used in templates, such as the {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'each' (query-params anchor='each')}}each{{/link-to}}, {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'on' (query-params anchor='on')}}on{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'fn' (query-params anchor='fn')}}fn{{/link-to}} helpers</li>
-    <li>{{#link-to 'project-version.classes.class' 'Helper'}}Helpers{{/link-to}} - a way to define custom display functions that are used in templates</li>
-    <li>{{#link-to 'project-version.classes.class' 'Route'}}Route{{/link-to}} - used to define individual routes, including the {{#link-to 'project-version.classes.class.methods.method' 'Route' 'model' (query-params anchor='model')}}model{{/link-to}} hook for loading data</li>
-    <li>{{#link-to 'project-version.classes.class' 'Service'}}Service{{/link-to}} - an Ember object that lives for the duration of the application, and can be made available in different parts of your application</li>
-  </ul>
-  <h2>Useful links</h2>
-  <ul>
-    <li>
-      <h5>
-        <a href="https://github.com/ember-learn/ember-api-docs">API Documentation Github Repository</a>
-      </h5>
-    </li>
-    <li>
-      <h5>
-        <a href="https://guides.emberjs.com/release/getting-started/core-concepts/">Ember Core Concepts</a>
-      </h5>
-    </li>
-  </ul>
-</article>
+{{#if (eq @model.id "ember-data")}}
+  <EmberDataLandingPage />
+{{else}}
+  <EmberLandingPage />
+{{/if}}

--- a/tests/acceptance/redirects-test.js
+++ b/tests/acceptance/redirects-test.js
@@ -15,16 +15,6 @@ module('Acceptance | redirects', function(hooks) {
     assert.dom('h1').hasText('Ember API Documentation');
   });
 
-  test('visiting /ember-data', async function (assert) {
-    await visit('/ember-data');
-    assert.equal(
-      currentURL(),
-      `/ember-data/release`,
-      'routes to the landing page'
-    );
-    assert.dom('h1').hasText('Ember API Documentation');
-  });
-
   test('visiting pre-2.16 version', async function(assert) {
     await visit('/ember/1.0');
 


### PR DESCRIPTION
Results of pairing with @jenweber 

This allows the ember-data team to maintain and update the overview for ember-data directly with each release, falling back to a built-in overview for versions for which the library did not yet provide one.

I've configured it to use the main from the module `ember-data-overview` as opposed to `ember-data` to ensure that any old releases that had `ember-data` as a module (current releases do not) won't accidentally trip into this behavior.

We should consider expanding this for the ember-cli and ember.js teams to utilize as well, it would be quite easy to do.

The `ember-data-overview` page is filtered from the modules that will appear in the sidebar to prevent confusion, since it is already the primary link for the project. This also allows us to re-use `ember-data` module main as an explainer for that particular package vs for the project as a whole.