### PR TITLE
Remove duplicate item from Ember landing page

### DIFF
--- a/app/components/ember-landing-page.hbs
+++ b/app/components/ember-landing-page.hbs
@@ -1,12 +1,12 @@
 <article class="chapter">
   <h1>Ember API Documentation</h1>
   <p>
-    To get started, choose a project (Ember or Ember Data) and a version 
-    from the dropdown menu. Ember has core methods used in any app, while Ember Data has 
+    To get started, choose a project (Ember or Ember Data) and a version
+    from the dropdown menu. Ember has core methods used in any app, while Ember Data has
     documentation of the built-in library for making requests to a back end.
-    If you're looking for documentation of the command line tool used to generate files, build your 
+    If you're looking for documentation of the command line tool used to generate files, build your
     app, and more, visit <a href="https://cli.emberjs.com/">ember-cli</a>. The latest
-    testing API is available at 
+    testing API is available at
     <a href="https://github.com/emberjs/ember-test-helpers/blob/master/API.md">ember-test-helpers</a>.
   </p>
   <h2>Commonly searched-for documentation</h2>
@@ -17,7 +17,6 @@
     <li>{{#link-to 'project-version.classes.class' '@ember/object/computed'}}Computed Macros{{/link-to}} - shorter ways of expressing certain types of computed properties</li>
     <li>{{#link-to 'project-version.classes.class' 'EmberArray'}}EmberArray{{/link-to}} - contains methods like {{#link-to 'project-version.classes.class.methods.method' 'EmberArray' 'forEach' (query-params anchor='forEach')}}forEach{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'EmberArray' 'mapBy' (query-params anchor='mapBy')}}mapBy{{/link-to}} that help you iterate over Ember Objects</li>
     <li>{{#link-to 'project-version.classes.class' 'EmberObject'}}EmberObject{{/link-to}} - the main base class for all Ember objects, including the {{#link-to 'project-version.classes.class.methods.method' 'EmberObject' 'get' (query-params anchor='get')}}get{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'EmberObject' 'set' (query-params anchor='set')}}set{{/link-to}} methods</li>
-    <li>{{#link-to 'project-version.classes.class' 'Ember.Templates.helpers'}}Ember.Templates.helpers{{/link-to}} - built-in functions that can be used in templates, such as the {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'each' (query-params anchor='each')}}each{{/link-to}} helper</li>
     <li>{{#link-to 'project-version.classes.class' 'Ember.Templates.helpers'}}Ember.Templates.helpers{{/link-to}} - built-in functions that can be used in templates, such as the {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'each' (query-params anchor='each')}}each{{/link-to}}, {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'on' (query-params anchor='on')}}on{{/link-to}} and {{#link-to 'project-version.classes.class.methods.method' 'Ember.Templates.helpers' 'fn' (query-params anchor='fn')}}fn{{/link-to}} helpers</li>
     <li>{{#link-to 'project-version.classes.class' 'Helper'}}Helpers{{/link-to}} - a way to define custom display functions that are used in templates</li>
     <li>{{#link-to 'project-version.classes.class' 'Route'}}Route{{/link-to}} - used to define individual routes, including the {{#link-to 'project-version.classes.class.methods.method' 'Route' 'model' (query-params anchor='model')}}model{{/link-to}} hook for loading data</li>


### PR DESCRIPTION
There are 2 almost similar items in the Commonly searched-for documentation section in the Ember [landing page](https://api.emberjs.com/ember/release). So this PR removes the one with less information.

![image](https://user-images.githubusercontent.com/5218190/124501648-31bd3280-dd7f-11eb-8991-ac2337b30d51.png)
