### PR TITLE
Update table of contents component to glimmer

### DIFF
--- a/app/components/table-of-contents.hbs
+++ b/app/components/table-of-contents.hbs
@@ -1,12 +1,12 @@
-<ol class="toc-level-0">
-  <li class="toc-level-0">
-    <a {{action 'toggle' 'modules'}} href="#" data-test-toc-title="packages">Packages</a>
-    <ol class="toc-level-1 modules selected">
+<ol class='toc-level-0'>
+  <li class='toc-level-0'>
+    <a {{action 'toggle' 'modules'}} href='#' data-test-toc-title='packages'>Packages</a>
+    <ol class='toc-level-1 modules selected'>
       {{#each @moduleIDs as |moduleID|}}
 
-        {{#if (not-eq moduleID "@ember/object/computed")}}
-          <li class="toc-level-1" data-test-module={{moduleID}}>
-            <LinkTo @route="project-version.modules.module" @models={{array @version moduleID}}>{{moduleID}}</LinkTo>
+        {{#if (not-eq moduleID '@ember/object/computed')}}
+          <li class='toc-level-1' data-test-module={{moduleID}}>
+            <LinkTo @route='project-version.modules.module' @models={{array @version moduleID}}>{{moduleID}}</LinkTo>
           </li>
         {{/if}}
 
@@ -15,30 +15,30 @@
   </li>
 
   {{#if @isShowingNamespaces}}
-    <li class="toc-level-0">
-      <a {{action 'toggle' 'namespaces'}} href="#" data-test-toc-title="namespaces">Namespaces</a>
-      <ol class="toc-level-1 namespaces selected">
+    <li class='toc-level-0'>
+      <a {{action 'toggle' 'namespaces'}} href='#' data-test-toc-title='namespaces'>Namespaces</a>
+      <ol class='toc-level-1 namespaces selected'>
         {{#each @namespaceIDs as |namespaceID|}}
-          <li class="toc-level-1" data-test-namespace={{namespaceID}}>
-            <LinkTo @route="project-version.namespaces.namespace" @models={{array @version namespaceID}}>{{namespaceID}}</LinkTo>
+          <li class='toc-level-1' data-test-namespace={{namespaceID}}>
+            <LinkTo @route='project-version.namespaces.namespace' @models={{array @version namespaceID}}>{{namespaceID}}</LinkTo>
           </li>
         {{/each}}
       </ol>
     </li>
   {{/if}}
 
-  <li class="toc-level-0">
-    <a {{action 'toggle' 'classes'}} href="#" data-test-toc-title="classes">Classes</a>
-    <ol class="toc-level-1 classes selected">
+  <li class='toc-level-0'>
+    <a {{action 'toggle' 'classes'}} href='#' data-test-toc-title='classes'>Classes</a>
+    <ol class='toc-level-1 classes selected'>
       {{#each @classesIDs as |classID|}}
-        <li class="toc-level-1" data-test-class={{classID}}>
-          <LinkTo @route="project-version.classes.class" @models={{array @version classID}}>{{classID}}</LinkTo>
+        <li class='toc-level-1' data-test-class={{classID}}>
+          <LinkTo @route='project-version.classes.class' @models={{array @version classID}}>{{classID}}</LinkTo>
         </li>
       {{/each}}
     </ol>
   </li>
 </ol>
-<label class="toc-private-toggle">
-  <Input @type="checkbox" @checked={{@showPrivateClasses}} class="private-deprecated-toggle" />
+<label class='toc-private-toggle'>
+  <Input @type='checkbox' @checked={{@showPrivateClasses}} class='private-deprecated-toggle' />
   Show Private / Deprecated
 </label>

--- a/app/components/table-of-contents.hbs
+++ b/app/components/table-of-contents.hbs
@@ -2,11 +2,11 @@
   <li class="toc-level-0">
     <a {{action 'toggle' 'modules'}} href="#" data-test-toc-title="packages">Packages</a>
     <ol class="toc-level-1 modules selected">
-      {{#each this.moduleIDs as |moduleID|}}
+      {{#each @moduleIDs as |moduleID|}}
 
         {{#if (not-eq moduleID "@ember/object/computed")}}
           <li class="toc-level-1" data-test-module={{moduleID}}>
-            <LinkTo @route="project-version.modules.module" @models={{array this.version moduleID}}>{{moduleID}}</LinkTo>
+            <LinkTo @route="project-version.modules.module" @models={{array @version moduleID}}>{{moduleID}}</LinkTo>
           </li>
         {{/if}}
 
@@ -14,13 +14,13 @@
     </ol>
   </li>
 
-  {{#if this.isShowingNamespaces}}
+  {{#if @isShowingNamespaces}}
     <li class="toc-level-0">
       <a {{action 'toggle' 'namespaces'}} href="#" data-test-toc-title="namespaces">Namespaces</a>
       <ol class="toc-level-1 namespaces selected">
-        {{#each this.namespaceIDs as |namespaceID|}}
+        {{#each @namespaceIDs as |namespaceID|}}
           <li class="toc-level-1" data-test-namespace={{namespaceID}}>
-            <LinkTo @route="project-version.namespaces.namespace" @models={{array this.version namespaceID}}>{{namespaceID}}</LinkTo>
+            <LinkTo @route="project-version.namespaces.namespace" @models={{array @version namespaceID}}>{{namespaceID}}</LinkTo>
           </li>
         {{/each}}
       </ol>
@@ -30,15 +30,15 @@
   <li class="toc-level-0">
     <a {{action 'toggle' 'classes'}} href="#" data-test-toc-title="classes">Classes</a>
     <ol class="toc-level-1 classes selected">
-      {{#each this.classesIDs as |classID|}}
+      {{#each @classesIDs as |classID|}}
         <li class="toc-level-1" data-test-class={{classID}}>
-          <LinkTo @route="project-version.classes.class" @models={{array this.version classID}}>{{classID}}</LinkTo>
+          <LinkTo @route="project-version.classes.class" @models={{array @version classID}}>{{classID}}</LinkTo>
         </li>
       {{/each}}
     </ol>
   </li>
 </ol>
 <label class="toc-private-toggle">
-  <Input @type="checkbox" @checked={{this.showPrivateClasses}} class="private-deprecated-toggle" />
+  <Input @type="checkbox" @checked={{@showPrivateClasses}} class="private-deprecated-toggle" />
   Show Private / Deprecated
 </label>

--- a/app/components/table-of-contents.js
+++ b/app/components/table-of-contents.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 export default class TableOfContents extends Component {
   @action

--- a/app/templates/project-version.hbs
+++ b/app/templates/project-version.hbs
@@ -28,7 +28,7 @@
     </PowerSelect>
   </div>
 
-  <TableOfContents @projectId={{this.model.project.id}} @version={{this.urlVersion}} @classesIDs={{this.shownClassesIDs}} @moduleIDs={{this.shownModuleIDs}} @namespaceIDs={{this.shownNamespaceIDs}} @showPrivateClasses={{this.showPrivateClasses}} @isShowingNamespaces={{version-lt this.selectedProjectVersion.compactVersion "2.16"}} />
+  <TableOfContents @version={{this.urlVersion}} @classesIDs={{this.shownClassesIDs}} @moduleIDs={{this.shownModuleIDs}} @namespaceIDs={{this.shownNamespaceIDs}} @showPrivateClasses={{this.showPrivateClasses}} @isShowingNamespaces={{version-lt this.selectedProjectVersion.compactVersion "2.16"}} />
 </aside>
 <section class="content">
   {{outlet}}

--- a/tests/integration/components/table-of-contents-test.js
+++ b/tests/integration/components/table-of-contents-test.js
@@ -12,14 +12,12 @@ module('Integration | Component | table of contents', function (hooks) {
 
   test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
-    this.set('projectId', 'Ember');
     this.set('emberVersion', '2.4.3');
     this.set('classesIDs', CLASSES);
 
     await render(hbs`
       {{
         table-of-contents showPrivateClasses=true
-          projectid=projectId
           version=emberVersion
           classesIDs=classesIDs
           isShowingNamespaces=true
@@ -41,14 +39,12 @@ module('Integration | Component | table of contents', function (hooks) {
 
   test('Starts with underlying content visible', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
-    this.set('projectId', 'Ember');
     this.set('emberVersion', '2.4.3');
     this.set('moduleIDs', MODULES);
 
     await render(hbs`
       {{
         table-of-contents showPrivateClasses=true
-          projectid=projectId
           version=emberVersion
           moduleIDs=moduleIDs
           isShowingNamespaces=true
@@ -73,14 +69,12 @@ module('Integration | Component | table of contents', function (hooks) {
 
   test('Underlying content hides once clicked', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
-    this.set('projectId', 'Ember');
     this.set('emberVersion', '2.4.3');
     this.set('moduleIDs', MODULES);
 
     await render(hbs`
       {{
         table-of-contents showPrivateClasses=true
-          projectid=projectId
           version=emberVersion
           moduleIDs=moduleIDs
           isShowingNamespaces=true
@@ -109,14 +103,12 @@ module('Integration | Component | table of contents', function (hooks) {
 
   test('Underlying content should be visible after 2 clicks', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
-    this.set('projectId', 'Ember');
     this.set('emberVersion', '2.4.3');
     this.set('moduleIDs', MODULES);
 
     await render(hbs`
       {{
         table-of-contents showPrivateClasses=true
-          projectid=projectId
           version=emberVersion
           moduleIDs=moduleIDs
           isShowingNamespaces=true


### PR DESCRIPTION
Let's update the TableOfContents component to extend glimmer/component instead of ember/component. Glimmer components offer a bunch of various advantages over classic components and are the direction that ember is
heading in general.

While we're here, let's prefer single quotes to double quotes throughout our template file and cleanup any unused arguments into this component. 

This should resolve the `app/components/table-of-contents.js` section of https://github.com/ember-learn/ember-api-docs/issues/805.