### PR TITLE
Update data tests to handle redirect to overview

### DIFF
--- a/tests/acceptance/convert-legacy-url-to-current-test.js
+++ b/tests/acceptance/convert-legacy-url-to-current-test.js
@@ -28,9 +28,12 @@ module('Acceptance | convert legacy url to current', function (hooks) {
     assert.equal(currentURL(), '/ember/release/modules/@ember%2Fapplication');
   });
 
-  test('should convert url for legacy ember data module to index', async function (assert) {
+  test('should convert url for legacy ember data module to overview', async function (assert) {
     await visit('/data/modules/ember-data.html');
-    assert.equal(currentURL(), '/ember-data/release');
+    assert.equal(
+      currentURL(),
+      '/ember-data/release/modules/ember-data-overview'
+    );
   });
 
   test('should convert unknown legacy modules url to landing page', async function (assert) {


### PR DESCRIPTION
Not quite sure how this ended up slipping past CI, but we didn't update the test which checks where you end up when you hit a legacy Data URL in the new world where there's a nice `@main`-driven landing page. This updates the test to match that.