### PR TITLE
Eliminate all local `no-implicit-this` errors

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -7,7 +7,6 @@ module.exports = {
     'attribute-indentation': false,
     'no-unnecessary-concat': false,
     'no-inline-styles': false,
-    'no-implicit-this': false,
     'no-curly-component-invocation': false,
     'no-action': false,
     quotes: false,

--- a/app/templates/components/search-input/dropdown-result.hbs
+++ b/app/templates/components/search-input/dropdown-result.hbs
@@ -28,7 +28,7 @@
           </div>
         </LinkTo>
       {{else}}
-        <LinkTo @route="project-version.classes.class.methods.method" @models={{array this.module this.version result.class result.name}} @query={{hash anchor=this.result.name}} data-test-search-result>
+        <LinkTo @route="project-version.classes.class.methods.method" @models={{array this.module this.version this.result.class this.result.name}} @query={{hash anchor=this.result.name}} data-test-search-result>
           <div class="algolia-docsearch-suggestion--subcategory-inline">
             {{!-- Sometimes hierarchy lvl1 is null, fall-back to lvl0 --}}
             {{#if this.result._highlightResult.hierarchy.lvl1}}

--- a/app/templates/project-version.hbs
+++ b/app/templates/project-version.hbs
@@ -28,7 +28,14 @@
     </PowerSelect>
   </div>
 
-  <TableOfContents @version={{this.urlVersion}} @classesIDs={{this.shownClassesIDs}} @moduleIDs={{this.shownModuleIDs}} @namespaceIDs={{this.shownNamespaceIDs}} @showPrivateClasses={{this.showPrivateClasses}} @isShowingNamespaces={{version-lt this.selectedProjectVersion.compactVersion "2.16"}} />
+  <TableOfContents
+    @version={{this.urlVersion}}
+    @classesIDs={{this.shownClassesIDs}}
+    @moduleIDs={{this.shownModuleIDs}}
+    @namespaceIDs={{this.shownNamespaceIDs}}
+    @showPrivateClasses={{this.showPrivateClasses}}
+    @isShowingNamespaces={{version-lt this.selectedProjectVersion.compactVersion "2.16"}}
+  />
 </aside>
 <section class="content">
   {{outlet}}

--- a/tests/integration/components/api-index-filter-test.js
+++ b/tests/integration/components/api-index-filter-test.js
@@ -86,34 +86,34 @@ module('Integration | Component | api index filter', function (hooks) {
     };
 
     await render(hbs`
-      {{#api-index-filter model=model filterData=filterData as |myModel|}}
+      {{#api-index-filter model=this.model filterData=this.filterData as |myModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id=\"protected-toggle\"
                      type=\"checkbox\"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" \"showProtected\"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id=\"private-toggle\"
                      type=\"checkbox\"
-                     checked={{sectionData.showPrivate}}
+                     checked={{this.sectionData.showPrivate}}
                      onchange={{action \"updateFilter\" \"showPrivate\"}}>
               Private
             </label>
             <label class="access-checkbox">
               <input id=\"deprecated-toggle\"
                      type=\"checkbox\"
-                     checked=\"{{sectionData.showDeprecated}}\"
+                     checked=\"{{this.sectionData.showDeprecated}}\"
                      onchange={{action \"updateFilter\" \"showDeprecated\"}}>
             </label>
           </section>
@@ -151,34 +151,34 @@ module('Integration | Component | api index filter', function (hooks) {
     };
 
     await render(hbs`
-      {{#api-index-filter model=model filterData=filterData updateFilter=(action "updateFilter") as |myModel|}}
+      {{#api-index-filter model=this.model filterData=this.filterData updateFilter=(action "updateFilter") as |myModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id=\"protected-toggle\"
                      type=\"checkbox\"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" \"showProtected\"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id="private-toggle"
                      type="checkbox"
-                     checked={{filterData.showPrivate}}
+                     checked={{this.filterData.showPrivate}}
                      onchange={{action "updateFilter" "showPrivate"}}>
               Private
             </label>
             <label class="access-checkbox">
               <input id=\"deprecated-toggle\"
                      type=\"checkbox\"
-                     checked=\"{{sectionData.showDeprecated}}\"
+                     checked=\"{{this.sectionData.showDeprecated}}\"
                      onchange={{action \"updateFilter\" \"showDeprecated\"}}>
             </label>
           </section>
@@ -216,34 +216,34 @@ module('Integration | Component | api index filter', function (hooks) {
     };
 
     await render(hbs`
-      {{#api-index-filter model=model filterData=filterData as |myModel|}}
+      {{#api-index-filter model=this.model filterData=this.filterData as |myModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id=\"protected-toggle\"
                      type=\"checkbox\"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" \"showProtected\"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id="private-toggle"
                      type="checkbox"
-                     checked={{filterData.showPrivate}}
+                     checked={{this.filterData.showPrivate}}
                      onchange={{action "updateFilter" "showPrivate"}}>
               Private
             </label>
             <label class="access-checkbox">
               <input id=\"deprecated-toggle\"
                      type=\"checkbox\"
-                     checked=\"{{sectionData.showDeprecated}}\"
+                     checked=\"{{this.sectionData.showDeprecated}}\"
                      onchange={{action \"updateFilter\" \"showDeprecated\"}}>
             </label>
           </section>
@@ -285,34 +285,34 @@ module('Integration | Component | api index filter', function (hooks) {
     };
 
     await render(hbs`
-      {{#api-index-filter model=model filterData=filterData as |myModel|}}
+      {{#api-index-filter model=this.model filterData=this.filterData as |myModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id="protected-toggle"
                      type="checkbox"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" "showProtected"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id="private-toggle"
                      type="checkbox"
-                     checked={{filterData.showPrivate}}
+                     checked={{this.filterData.showPrivate}}
                      onchange={{action "updateFilter" "showPrivate"}}>
               Private
             </label>
             <label class="access-checkbox">
               <input id="deprecated-toggle"
                      type="checkbox"
-                     checked="{{filterData.showDeprecated}}"
+                     checked="{{this.filterData.showDeprecated}}"
                      onchange={{action "updateFilter" "showDeprecated"}}>
             </label>
           </section>
@@ -362,34 +362,34 @@ module('Integration | Component | api index filter', function (hooks) {
     };
 
     await render(hbs`
-      {{#api-index-filter model=model filterData=filterData as |myModel|}}
+      {{#api-index-filter model=this.model filterData=this.filterData as |myModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id="protected-toggle"
                      type="checkbox"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" "showProtected"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id="private-toggle"
                      type="checkbox"
-                     checked={{filterData.showPrivate}}
+                     checked={{this.filterData.showPrivate}}
                      onchange={{action "updateFilter" "showPrivate"}}>
               Private
             </label>
             <label class="access-checkbox">
               <input id="deprecated-toggle"
                      type="checkbox"
-                     checked="{{filterData.showDeprecated}}"
+                     checked="{{this.filterData.showDeprecated}}"
                      onchange={{action "updateFilter" "showDeprecated"}}>
             </label>
           </section>
@@ -444,7 +444,7 @@ module('Integration | Component | api index filter', function (hooks) {
     this.set('filterData', filterData);
 
     await render(hbs`
-      {{#api-index-filter model=model filterData=filterData as |myModel|}}
+      {{#api-index-filter model=this.model filterData=this.filterData as |myModel|}}
           <h2>Methods</h2>
           {{#each myModel.methods as |method|}}
             <p class=\"method-name\">{{method.name}}</p>

--- a/tests/integration/components/api-index-test.js
+++ b/tests/integration/components/api-index-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | api index', function (hooks) {
 
     // Template block usage:
     await render(hbs`
-        {{#api-index itemData=myModel as |sectionData|}}
+        {{#api-index itemData=this.myModel as |sectionData|}}
           {{#each sectionData.sections as |section|}}
             <h2 class=\"api-index-section-title\">{{section.title}}</h2>
             {{#if section.items}}
@@ -123,7 +123,7 @@ module('Integration | Component | api index', function (hooks) {
 
     // Template block usage:
     await render(hbs`
-        {{#api-index itemData=myModel as |sectionData|}}
+        {{#api-index itemData=this.myModel as |sectionData|}}
           {{#each sectionData.sections as |section|}}
             <h2 class=\"api-index-section-title\">{{section.title}}</h2>
             {{#if section.items}}
@@ -237,34 +237,34 @@ module('Integration | Component | api index', function (hooks) {
 
     // Template block usage:
     await render(hbs`
-      {{#api-index-filter model=myModel filterData=filterData as |filteredModel|}}
+      {{#api-index-filter model=this.myModel filterData=this.filterData as |filteredModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id=\"protected-toggle\"
                      type=\"checkbox\"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" \"showProtected\"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id="private-toggle"
                      type="checkbox"
-                     checked={{filterData.showPrivate}}
+                     checked={{this.filterData.showPrivate}}
                      onchange={{action "updateFilter" "showPrivate"}}>
               Private
             </label>
             <label class="access-checkbox">
               <input id=\"deprecated-toggle\"
                      type=\"checkbox\"
-                     checked=\"{{sectionData.showDeprecated}}\"
+                     checked=\"{{this.filterData.showDeprecated}}\"
                      onchange={{action \"updateFilter\" \"showDeprecated\"}}>
             </label>
           </section>
@@ -383,34 +383,35 @@ module('Integration | Component | api index', function (hooks) {
     };
 
     await render(hbs`
-      {{#api-index-filter model=myModel filterData=filterData as |filteredModel|}}
+      {{#api-index-filter model=this.myModel filterData=this.filterData as |filteredModel|}}
           <section>
             Show:
             <label class="access-checkbox">
               <input id="inherited-toggle"
                      type="checkbox"
-                     checked="{{filterData.showInherited}}"
+                     checked="{{this.filterData.showInherited}}"
                      onchange={{action "updateFilter" "showInherited"}}>
               Inherited
             </label>
             <label class="access-checkbox">
               <input id=\"protected-toggle\"
                      type=\"checkbox\"
-                     checked={{filterData.showProtected}}
+                     checked={{this.filterData.showProtected}}
                      onchange={{action "updateFilter" \"showProtected\"}}>
               Protected
             </label>
             <label class="access-checkbox">
               <input id="private-toggle"
                      type="checkbox"
-                     checked={{filterData.showPrivate}}
+                     checked={{this.filterData.showPrivate}}
                      onchange={{action "updateFilter" "showPrivate"}}>
               Private
             </label>
+            {{! TODO: investigate this 'checked=': it looks wrong!}}
             <label class="access-checkbox">
               <input id=\"deprecated-toggle\"
                      type=\"checkbox\"
-                     checked=\"{{sectionData.showDeprecated}}\"
+                     checked=\"{{this.sectionData.showDeprecated}}\"
                      onchange={{action \"updateFilter\" \"showDeprecated\"}}>
             </label>
           </section>

--- a/tests/integration/helpers/is-latest-test.js
+++ b/tests/integration/helpers/is-latest-test.js
@@ -14,7 +14,7 @@ module('helper:is-latest', function (hooks) {
     this.set('allVersions', versions);
 
     await render(hbs`
-  {{#if (is-latest version=version allVersions=allVersions)}}
+  {{#if (is-latest version=this.version allVersions=this.allVersions)}}
     Hello World
   {{/if}}
   `);
@@ -26,7 +26,7 @@ module('helper:is-latest', function (hooks) {
     this.set('version', '3.1.0');
     this.set('allVersions', versions);
     await render(hbs`
-  {{#if (is-latest version=version allVersions=allVersions)}}
+  {{#if (is-latest version=this.version allVersions=this.allVersions)}}
     Hello World
   {{/if}}
   `);


### PR DESCRIPTION
To get rid of the rest of these, we're going to need to tackle some more dependencies: mostly ember-styleguide.

Besides removing the remaining issues locally, I flagged up a suspicious thing in a test, to come back to later, and enabled the template-lint warning to catch these going forward *outside* of tests.