### PR TITLE
Follow-up items from updating table of contents component to glimmer

### DIFF
--- a/app/components/table-of-contents.hbs
+++ b/app/components/table-of-contents.hbs
@@ -39,6 +39,6 @@
   </li>
 </ol>
 <label class='toc-private-toggle'>
-  <Input @type='checkbox' @checked={{@showPrivateClasses}} class='private-deprecated-toggle' />
+  <input type='checkbox' checked={{@showPrivateClasses}} onchange={{@togglePrivateClasses}} class='private-deprecated-toggle' />
   Show Private / Deprecated
 </label>

--- a/app/components/table-of-contents.hbs
+++ b/app/components/table-of-contents.hbs
@@ -1,6 +1,6 @@
 <ol class='toc-level-0'>
   <li class='toc-level-0'>
-    <a {{action 'toggle' 'modules'}} href='#' data-test-toc-title='packages'>Packages</a>
+    <a {{on 'click' (fn this.toggle 'modules')}} href='#' data-test-toc-title='packages'>Packages</a>
     <ol class='toc-level-1 modules selected'>
       {{#each @moduleIDs as |moduleID|}}
 
@@ -16,7 +16,7 @@
 
   {{#if @isShowingNamespaces}}
     <li class='toc-level-0'>
-      <a {{action 'toggle' 'namespaces'}} href='#' data-test-toc-title='namespaces'>Namespaces</a>
+      <a {{on 'click' (fn this.toggle 'namespaces')}} href='#' data-test-toc-title='namespaces'>Namespaces</a>
       <ol class='toc-level-1 namespaces selected'>
         {{#each @namespaceIDs as |namespaceID|}}
           <li class='toc-level-1' data-test-namespace={{namespaceID}}>
@@ -28,7 +28,7 @@
   {{/if}}
 
   <li class='toc-level-0'>
-    <a {{action 'toggle' 'classes'}} href='#' data-test-toc-title='classes'>Classes</a>
+    <a {{on 'click' (fn this.toggle 'classes')}} href='#' data-test-toc-title='classes'>Classes</a>
     <ol class='toc-level-1 classes selected'>
       {{#each @classesIDs as |classID|}}
         <li class='toc-level-1' data-test-class={{classID}}>

--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -1,5 +1,5 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes */
-import { computed } from '@ember/object';
+import { action, computed, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { readOnly, alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
@@ -121,4 +121,9 @@ export default class ProjectVersionController extends Controller {
 
   @readOnly('model.project.id')
   activeProject;
+
+  @action
+  togglePrivateClasses() {
+    set(this, 'showPrivateClasses', !this.showPrivateClasses);
+  }
 }

--- a/app/templates/project-version.hbs
+++ b/app/templates/project-version.hbs
@@ -34,6 +34,7 @@
     @moduleIDs={{this.shownModuleIDs}}
     @namespaceIDs={{this.shownNamespaceIDs}}
     @showPrivateClasses={{this.showPrivateClasses}}
+    @togglePrivateClasses={{this.togglePrivateClasses}}
     @isShowingNamespaces={{version-lt this.selectedProjectVersion.compactVersion "2.16"}}
   />
 </aside>


### PR DESCRIPTION
Let's follow-up on the suggested tweaks to the table-of-contents component from: https://github.com/ember-learn/ember-api-docs/pull/809 by:

1.  avoiding the `action` helper 
2. avoiding the `Input` component which provides a 2-way binding on the `@checked` arg

