### PR TITLE
Set Node to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "typescript": "^4.9.3"
   },
   "engines": {
-    "node": "14.* || 16.* || 18.*",
+    "node": "14.*",
     "npm": "7 || 8 || 9"
   },
   "cacheDirectories": [


### PR DESCRIPTION
To accommodate libsass, and make this deployable to Heroku, we need to stay at v14 of node.

We can upgrade the node version once we update ember-styleguide.

This reinstates the work in https://github.com/ember-learn/ember-api-docs/pull/834 which had a regression in https://github.com/ember-learn/ember-api-docs/pull/835