### PR TITLE
Improve Ember Data Overview heading

### DIFF
--- a/app/templates/project-version/modules/module.hbs
+++ b/app/templates/project-version/modules/module.hbs
@@ -1,5 +1,9 @@
 <article class="chapter">
-  <h1 class="module-name">Package {{this.model.name}}</h1>
+  {{#if (eq this.model.name 'ember-data-overview')}}
+    <h1 class="module-name">Ember Data Overview</h1>
+  {{else}}
+    <h1 class="module-name">Package {{this.model.name}}</h1>
+  {{/if}}
   {{#if this.model.access}}<span class="access">{{this.model.access}}</span>{{/if}}
 
   <p class="attributes">

--- a/app/templates/project-version/modules/module.hbs
+++ b/app/templates/project-version/modules/module.hbs
@@ -1,6 +1,6 @@
 <article class="chapter">
   {{#if (eq this.model.name 'ember-data-overview')}}
-    <h1 class="module-name">Ember Data Overview</h1>
+    <h1 class="module-name">EmberData Overview</h1>
   {{else}}
     <h1 class="module-name">Package {{this.model.name}}</h1>
   {{/if}}


### PR DESCRIPTION
If the Ember Data overview is showing, give a more reasonable title instead of "Package ember-data-overview"

## Before

<img width="1376" alt="Screen Shot 2023-01-27 at 9 16 45 AM" src="https://user-images.githubusercontent.com/16627268/215108350-b25eaec9-e348-4a00-852f-6f4687552bdb.png">


## After

<img width="1249" alt="Screen Shot 2023-01-27 at 9 16 31 AM" src="https://user-images.githubusercontent.com/16627268/215108370-75f6d04a-21bd-4e2c-ac27-b3fc118c5f48.png">
