### PR TITLE
Fix infinite redirects for ember data

### DIFF
--- a/app/routes/project-version.js
+++ b/app/routes/project-version.js
@@ -62,7 +62,8 @@ export default class ProjectVersionRoute extends Route {
     let transitionVersion = this.projectService.getUrlVersion();
     if (
       moduleParams?.module === 'ember-data-overview' &&
-      semverCompare(transitionVersion, '4.7') < 0
+      semverCompare(transitionVersion, '4.7') < 0 &&
+      transitionVersion !== 'release' // infinite redirects happen without this line
     ) {
       return this.router.transitionTo('project-version.index');
     }


### PR DESCRIPTION
Visiting ember-data/release caused many redirects, since semverCompare('release', '4.7') is < 0

Nothing like a little hotfix 🌶️ on a cold winter night

Thank you @bertdeblock and @NullVoxPopuli for flagging & confirming.