### PR TITLE
skip tests that are broken because of invalid data in production

### DIFF
--- a/tests/acceptance/function-test.js
+++ b/tests/acceptance/function-test.js
@@ -5,8 +5,19 @@ import { visit, find } from '@ember/test-helpers';
 module('Acceptance | Function', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('shows function when loaded from url', async function (assert) {
+  test.skip('shows function when loaded from url', async function (assert) {
     await visit('ember/2.18/functions/@ember%2Fapplication/getOwner');
+
+    assert.dom('.method').exists({ count: 1 }, 'Single function per page');
+    assert.equal(
+      find('.method .method-name').innerText,
+      'getOwner',
+      'Correct function is shown'
+    );
+  });
+
+  test('shows function when loaded from url in a more modern version', async function (assert) {
+    await visit('ember/3.28/functions/@ember%2Fapplication/getOwner');
 
     assert.dom('.method').exists({ count: 1 }, 'Single function per page');
     assert.equal(

--- a/tests/acceptance/switch-versions-test.js
+++ b/tests/acceptance/switch-versions-test.js
@@ -271,7 +271,7 @@ module('Acceptance | version navigation', function (hooks) {
     );
   });
 
-  test('switching versions works if class name includes slashes', async function (assert) {
+  test.skip('switching versions works if class name includes slashes', async function (assert) {
     await visit('/ember/3.4/classes/@ember%2Fobject%2Fcomputed');
     assert.equal(
       currentURL(),
@@ -287,7 +287,23 @@ module('Acceptance | version navigation', function (hooks) {
     );
   });
 
-  test(`switching versions works if we've previously switched for a different class`, async function (assert) {
+  test('switching versions works if class name includes slashes for more modern versions', async function (assert) {
+    await visit('/ember/3.13/classes/@ember%2Fobject%2Fcomputed');
+    assert.equal(
+      currentURL(),
+      '/ember/3.13/classes/@ember%2Fobject%2Fcomputed',
+      'navigated to v3.13 class'
+    );
+    await selectChoose('.ember-power-select-trigger', '3.20');
+    await waitForSettled();
+    assert.equal(
+      currentURL(),
+      '/ember/3.20/classes/@ember%2Fobject%2Fcomputed',
+      'navigated to v3.20 class'
+    );
+  });
+
+  test.skip(`switching versions works if we've previously switched for a different class`, async function (assert) {
     await visit('/ember/3.4/classes/@ember%2Fobject%2Fcomputed');
     assert.equal(
       currentURL(),
@@ -313,6 +329,36 @@ module('Acceptance | version navigation', function (hooks) {
       currentURL(),
       '/ember/2.18/classes/Component',
       'navigated to v2.18 for new class'
+    );
+  });
+
+  test(`switching versions works if we've previously switched for a different class (for more modern versions)`, async function (assert) {
+    await visit('/ember/3.13/classes/@ember%2Fobject%2Fcomputed');
+    assert.equal(
+      currentURL(),
+      '/ember/3.13/classes/@ember%2Fobject%2Fcomputed',
+      'navigated to v3.13 class'
+    );
+    await selectChoose('.ember-power-select-trigger', '3.20');
+    await waitForSettled();
+    assert.equal(
+      currentURL(),
+      '/ember/3.20/classes/@ember%2Fobject%2Fcomputed',
+      'navigated to v3.20 class'
+    );
+
+    await visit('/ember/3.25/classes/Component');
+    assert.equal(
+      currentURL(),
+      '/ember/3.25/classes/Component',
+      'navigated to new class'
+    );
+    await selectChoose('.ember-power-select-trigger', '3.15');
+    await waitForSettled();
+    assert.equal(
+      currentURL(),
+      '/ember/3.15/classes/Component',
+      'navigated to v3.15 for new class'
     );
   });
 


### PR DESCRIPTION
Our tests currently rely on downloading data from the real API (a problem but something we have a plan for 🙈)  but there was an issue with a recent deployment that caused some URLs to fail

e.g. https://api.emberjs.com/ember/3.13/functions/@ember%2Fapplication/getOwner works but https://api.emberjs.com/ember/3.12/functions/@ember%2Fapplication/getOwner does not

To unblock all PRs to this repo I'm just skipping tests that rely on that data and duplicating them to use more modern versions that aren't broken 👍 we can un-skip the old tests once the issue with the production data is fixed 