### PR TITLE
bugfix: hot-fix for blank pages on some routes

### DIFF
--- a/app/templates/project-version/classes/class.hbs
+++ b/app/templates/project-version/classes/class.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable no-action }}
 <article class="chapter">
-  {{#if (is-latest version=@model.projectVersion.version allVersions=this.allVersions)}}
+  {{#if (and @model.project.id @model.file @model.line (is-latest version=@model.projectVersion.version allVersions=this.allVersions))}}
     <a data-tooltip="Edit on Github" class="heading__link__edit" href="{{github-link @model.project.id @model.projectVersion.version @model.file @model.line isEdit=true}}" target="_blank" rel="noopener noreferrer">{{svg-jar "fa-pencil"}}</a>
   {{/if}}
   <h1 class="module-name">Class {{@model.name}}</h1>


### PR DESCRIPTION
as noted in #865 you get a blank page when visiting pages like:
- https://api.emberjs.com/ember/3.28/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo
- http://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input

The immediate cause for the bug is the "Edit on Github" button breaking the page:
<img width="332" alt="Screenshot 2023-05-30 at 7 06 06 PM" src="https://github.com/ember-learn/ember-api-docs/assets/3137126/13b4f3e0-2fa4-4ff0-9a01-e7b11e972e77">

From my findings something is causing these page to render twice, the first time `model.project.id` is `undefined` for some reason. This causes the latest version check in the conditional to break. Imo avoiding this initial render would be the optimal fix so if anyone has an idea whats causing it that would be good!

For now I suggest a hot fix to check if `model.project.id` exists before rendering the component as well as `model.file` and `model.line` since they are also undefined for some reason. The component shouldn't be rendered anyways if any of these are undefined since it will just be a dead link.