### PR TITLE
Clear stale search results when version is changed

### DIFF
--- a/app/components/search-input.js
+++ b/app/components/search-input.js
@@ -56,6 +56,10 @@ export default class SearchInput extends Component {
   }
 
   @action onfocus() {
+    if (this.query.length > 0 && this.searchService.hasStaleResults()) {
+      this.searchService.search.perform(this.query);
+    }
+
     this._focused = true;
   }
 

--- a/app/services/search.js
+++ b/app/services/search.js
@@ -9,6 +9,9 @@ export default Service.extend({
   _projectService: service('project'),
   _projectVersion: alias('_projectService.version'),
 
+  /** @type {?string} */
+  _lastQueriedProjectVersion: null,
+
   results: emberArray(),
 
   search: task(function* (query) {
@@ -30,6 +33,8 @@ export default Service.extend({
       query,
     };
 
+    this._lastQueriedProjectVersion = projectVersion;
+
     return set(this, 'results', yield this.doSearch(searchObj, params));
   }).restartable(),
 
@@ -37,5 +42,16 @@ export default Service.extend({
     return this._algoliaService
       .search(searchObj, params)
       .then((results) => results.hits);
+  },
+
+  /**
+   * Whenever the version changes in service:project, the results in this
+   * service become stale. Presenting them any further could allow the user to
+   * undo their version change by clicking a stale link.
+   * @returns {boolean}
+   */
+  hasStaleResults() {
+    return this._lastQueriedProjectVersion !== null
+    && this._projectVersion !== this._lastQueriedProjectVersion;
   },
 });


### PR DESCRIPTION
Possible fix for #872. This approach replaces the stale search results just in time whenever the search results dropdown is about to display.

By doing it this way we don't have to clear the user's search term whenever they change versions. They can pick up right where they left off, but with fresh search results.

todo
- [ ] needs tests
- [ ] clearing the results before calling `search.perform()` may eliminate the flash of stale content inside the dropdown
- [ ] what happens if they change projects, but leave version alone?