### PR TITLE
Update README to include fully local run

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please also see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Running in your local environment
 
-The Prembered version of the ember-api-docs expects a folder in its root that links to the `ember-api-docs-data` folder, so you can either use the `npm run clone` script to clone the `ember-api-docs-data` repo into `ember-api-docs`, OR you can create a symbolic link to `ember-api-docs-data` from `ember-api-docs`. You might want to sym-link `ember-api-docs-data` if you are generating new versions of the docs files with `ember-jsonapi-docs`, otherwise you can probably use the clone script.
+ember-api-docs expects a folder in its root that links to the `ember-api-docs-data` folder, so you can either use the `npm run clone` script to clone the `ember-api-docs-data` repo into `ember-api-docs`, OR you can create a symbolic link to `ember-api-docs-data` from `ember-api-docs`. You might want to sym-link `ember-api-docs-data` if you are generating new versions of the docs files with `ember-jsonapi-docs`, otherwise you can probably use the clone script.
 
 ### Quickstart to run locally
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ Clone all of the following repositories into the same directory so they are "sib
 
 ```sh
 git clone https://github.com/ember-learn/ember-api-docs-data
-cd ../ember-api-docs-data
-npm install
-cd ..
 git clone https://github.com/ember-learn/ember-api-docs
 cd ember-api-docs
 ln -s ../ember-api-docs-data

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ ember serve
 ```
 View at http://localhost:4200
 
+## Run fully-locally using `ember-api-docs-data`
+
+The Prembered version of the ember-api-docs expects a folder in its root that links to the `ember-api-docs-data` folder, so all you need to do is create a symbolic link to ember-api-docs-data and you can see the app running locally.
+
+Clone all of the following repositories into the same directory so they are "siblings" on the file system
+
+- This repository, `ember-api-docs`
+- [ember-data](https://github.com/emberjs/data/)
+
+```sh
+git clone https://github.com/ember-learn/ember-api-docs-data
+cd ../ember-api-docs-data
+npm install
+cd ..
+git clone https://github.com/ember-learn/ember-api-docs
+cd ember-api-docs
+ln -s ../ember-api-docs-data # assuming it's checked out in the same folder
+npm install
+npm start
+```
+
+Visit the app in your browser at [http://localhost:4200](http://localhost:4200)
+
 ## a11y testing
 
 To run a11y tests, run `test_a11y=yes ember serve`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Some tips for working with git/GitHub can be found in
 
 Please also see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Quickstart to run semi-locally
+## Running in your local environment
+
+The Prembered version of the ember-api-docs expects a folder in its root that links to the `ember-api-docs-data` folder, so you can either use the `npm run clone` script to clone the `ember-api-docs-data` repo into `ember-api-docs`, OR you can create a symbolic link to `ember-api-docs-data` from `ember-api-docs`. You might want to sym-link `ember-api-docs-data` if you are generating new versions of the docs files with `ember-jsonapi-docs`, otherwise you can probably use the clone script.
+
+### Quickstart to run locally
 
 Follow these instructions to run the app using publically available online data.
 You do not need to run [ember-jsonapi-docs](https://github.com/ember-learn/ember-jsonapi-docs)
@@ -43,15 +47,14 @@ locally yourself.
 git clone https://github.com/ember-learn/ember-api-docs.git
 cd ember-api-docs
 npm install
-ember serve
+npm run clone
+npm run start
 ```
 View at http://localhost:4200
 
-## Run fully-locally using `ember-api-docs-data`
+### Run locally with a sym-link
 
-The Prembered version of the ember-api-docs expects a folder in its root that links to the `ember-api-docs-data` folder, so all you need to do is create a symbolic link to ember-api-docs-data and you can see the app running locally.
-
-Clone all of the following repositories into the same directory so they are "siblings" on the file system
+Clone all of the following repositories into the same directory so they are "siblings" on the file system:
 
 - This repository, `ember-api-docs`
 - [ember-api-docs-data](https://github.com/ember-learn/ember-api-docs-data)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Prembered version of the ember-api-docs expects a folder in its root that li
 Clone all of the following repositories into the same directory so they are "siblings" on the file system
 
 - This repository, `ember-api-docs`
-- [ember-data](https://github.com/emberjs/data/)
+- [ember-api-docs-data](https://github.com/ember-learn/ember-api-docs-data)
 
 ```sh
 git clone https://github.com/ember-learn/ember-api-docs-data

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm install
 cd ..
 git clone https://github.com/ember-learn/ember-api-docs
 cd ember-api-docs
-ln -s ../ember-api-docs-data # assuming it's checked out in the same folder
+ln -s ../ember-api-docs-data
 npm install
 npm start
 ```


### PR DESCRIPTION
- the instructions to run ember-api-docs and ember-api-docs-data fully locally were housed in ember-jsonapi-docs, but having them here in the actual frontend seems a bit more intuitive
- this related PR makes ember-jsonapi-docs point here to this readme for running ember-api-docs fully locally https://github.com/ember-learn/ember-jsonapi-docs/pull/135
- as does this PR for ember-api-docs-data https://github.com/ember-learn/ember-api-docs-data/pull/22