### PR TITLE
refactor: allow @warp-drive in data docs

### DIFF
--- a/app/routes/project-version/modules/module.js
+++ b/app/routes/project-version/modules/module.js
@@ -18,7 +18,7 @@ export default class ModuleRoute extends ClassRoute.extend(ScrollTracker) {
 
     // These modules should not have `ember-` tacked onto the front of them
     // when forming the ids and URLs.
-    let isNotEmber = klass.match(/@glimmer|rsvp|jquery/);
+    let isNotEmber = klass.match(/@warp-drive|@glimmer|rsvp|jquery/);
 
     if (!~klass.indexOf(project) && !isNotEmber) {
       klass = `${project}-${klass}`;

--- a/tests/acceptance/warp-drive-test.js
+++ b/tests/acceptance/warp-drive-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+
+module('Acceptance | WarpDrive', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('can visit a @warp-drive package', async function (assert) {
+    await visit(
+      '/ember-data/release/modules/@warp-drive%2Fbuild-config%2Fdeprecations'
+    );
+
+    assert
+      .dom('.module-name')
+      .includesText('Package @warp-drive/build-config/deprecations');
+  });
+});


### PR DESCRIPTION
This is a demo of having run ember-api-docs against ember-api-docs-data with ember-data v5.3.8 built. 

Tests will pass after https://github.com/ember-learn/ember-api-docs-data/pull/32 is merged.

![2024-07-06 11 57 18](https://github.com/ember-learn/ember-api-docs/assets/6305935/d68bb638-5d13-419e-b39b-9b187e9414a2)
