### PR TITLE
go back to using main branch for data

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "scripts": {
-    "clone": "rm -rf ember-api-docs-data && git clone -b markdown --depth=1 https://github.com/ember-learn/ember-api-docs-data.git",
+    "clone": "rm -rf ember-api-docs-data && git clone --depth=1 https://github.com/ember-learn/ember-api-docs-data.git",
     "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",


### PR DESCRIPTION
Now that https://github.com/ember-learn/ember-api-docs-data/pull/25 is merged we can go back to using main branch for our data 👍 