### PR TITLE
stop requesting mappings over the network and fix shoebox usage

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -29,13 +29,8 @@ export default class Application extends JSONAPIAdapter {
     return false;
   }
 
-  shouldBackgroundReloadRecord(store, { modelName, id }) {
-    let key = `${modelName}-${id}`;
-    let hasId = this.ids[key];
-    if (!hasId) {
-      this.ids[key] = true;
-    }
-    return !hasId;
+  shouldBackgroundReloadRecord() {
+    return false;
   }
 
   constructor() {

--- a/app/routes/class.js
+++ b/app/routes/class.js
@@ -10,19 +10,13 @@ export default class ClassRoute extends Route {
   legacyModuleMappings;
 
   model(params) {
-    return this.legacyModuleMappings
-      .fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        let ret = {
-          mappings: this.legacyModuleMappings.buildMappings(mappings),
-          className: params['class'].substr(
-            0,
-            params['class'].lastIndexOf('.')
-          ),
-        };
-        return ret;
-      });
+    let ret = {
+      mappings: this.legacyModuleMappings.buildMappings(
+        this.legacyModuleMappings.legacyMappings
+      ),
+      className: params['class'].substr(0, params['class'].lastIndexOf('.')),
+    };
+    return ret;
   }
 
   redirect(model) {

--- a/app/routes/data-class.js
+++ b/app/routes/data-class.js
@@ -10,18 +10,12 @@ export default class DataClassRoute extends Route {
   legacyModuleMappings;
 
   model(params) {
-    return this.legacyModuleMappings
-      .fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        return {
-          mappings: this.legacyModuleMappings.buildMappings(mappings),
-          className: params['class'].substr(
-            0,
-            params['class'].lastIndexOf('.')
-          ),
-        };
-      });
+    return {
+      mappings: this.legacyModuleMappings.buildMappings(
+        this.legacyModuleMappings.legacyMappings
+      ),
+      className: params['class'].substr(0, params['class'].lastIndexOf('.')),
+    };
   }
 
   redirect(model) {

--- a/app/routes/data-module.js
+++ b/app/routes/data-module.js
@@ -10,15 +10,12 @@ export default class DataModuleRoute extends Route {
   legacyModuleMappings;
 
   model(params) {
-    return this.legacyModuleMappings
-      .fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        return {
-          moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
-          mappings: this.legacyModuleMappings.buildMappings(mappings),
-        };
-      });
+    return {
+      moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
+      mappings: this.legacyModuleMappings.buildMappings(
+        this.legacyModuleMappings.legacyMappings
+      ),
+    };
   }
 
   redirect(model) {

--- a/app/routes/module.js
+++ b/app/routes/module.js
@@ -10,15 +10,12 @@ export default class ModuleRoute extends Route {
   legacyModuleMappings;
 
   model(params) {
-    return this.legacyModuleMappings
-      .fetch()
-      .then((response) => response.json())
-      .then((mappings) => {
-        return {
-          moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
-          mappings: this.legacyModuleMappings.buildMappings(mappings),
-        };
-      });
+    return {
+      moduleName: params.module.substr(0, params.module.lastIndexOf('.')),
+      mappings: this.legacyModuleMappings.buildMappings(
+        this.legacyModuleMappings.legacyMappings
+      ),
+    };
   }
 
   redirect(model) {

--- a/app/routes/project-version/classes/class.js
+++ b/app/routes/project-version/classes/class.js
@@ -33,7 +33,10 @@ export default class ClassRoute extends Route.extend(ScrollTracker) {
       this.metaStore
     );
     const klass = params['class'];
-    return this.find('class', `${project}-${projectVersion}-${klass}`);
+    return this.find(
+      'class',
+      `${project}-${projectVersion}-${klass}`.toLowerCase()
+    );
   }
 
   find(typeName, param) {

--- a/app/services/legacy-module-mappings.js
+++ b/app/services/legacy-module-mappings.js
@@ -1,6 +1,7 @@
-import fetch from 'fetch';
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+
+import legacyMappings from 'ember-rfc176-data/mappings.json';
 
 const LOCALNAME_CONVERSIONS = {
   Object: 'EmberObject',
@@ -10,12 +11,11 @@ const LOCALNAME_CONVERSIONS = {
 
 export default class LegacyModuleMappingsService extends Service {
   @tracked mappings;
+  legacyMappings = legacyMappings;
 
   async initMappings() {
     try {
-      let response = await this.fetch();
-      let mappings = await response.json();
-      let newMappings = this.buildMappings(mappings);
+      let newMappings = this.buildMappings(legacyMappings);
       this.mappings = newMappings;
     } catch (e) {
       this.mappings = [];
@@ -30,10 +30,6 @@ export default class LegacyModuleMappingsService extends Service {
       }
       return newItem;
     });
-  }
-
-  fetch() {
-    return fetch('/assets/mappings.json');
   }
 
   getModule(name, documentedModule) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-const Funnel = require('broccoli-funnel');
-const mergeTrees = require('broccoli-merge-trees');
 const envIsProduction = process.env.EMBER_ENV === 'production';
 const premberUrls = require('./prember-urls');
 const nodeSass = require('node-sass');
@@ -57,12 +55,6 @@ module.exports = function (defaults) {
     },
   });
 
-  let mappingsTree = new Funnel('node_modules/ember-rfc176-data/', {
-    srcDir: '/',
-    include: ['mappings.json'],
-    destDir: '/assets/',
-  });
-
   const { Webpack } = require('@embroider/webpack');
   const appTree = require('@embroider/compat').compatBuild(app, Webpack, {
     staticAddonTrees: true,
@@ -72,5 +64,5 @@ module.exports = function (defaults) {
     staticComponents: true,
   });
 
-  return mergeTrees([require('prember').prerender(app, appTree), mappingsTree]);
+  return require('prember').prerender(app, appTree);
 };

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "bourbon-neat": "^1.9.1",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^2.0.1",
-    "broccoli-merge-trees": "^2.0.0",
     "ember-a11y-testing": "^5.2.1",
     "ember-anchor": "^1.0.3",
     "ember-auto-import": "^2.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       broccoli-funnel:
         specifier: ^2.0.1
         version: 2.0.2
-      broccoli-merge-trees:
-        specifier: ^2.0.0
-        version: 2.0.1
       ember-a11y-testing:
         specifier: ^5.2.1
         version: 5.2.1(@babel/core@7.24.7)(@ember/test-helpers@2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@0.9.7(@glimmer/component@1.1.2(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@3.2.7(@babel/core@7.24.7)))(ember-source@3.28.12(@babel/core@7.24.7)))(qunit@2.21.0)(webpack@5.91.0)

--- a/tests/acceptance/class-test.js
+++ b/tests/acceptance/class-test.js
@@ -15,7 +15,7 @@ module('Acceptance | Class', function (hooks) {
 
   test('lists all the methods on the class page', async function (assert) {
     const store = this.owner.lookup('service:store');
-    const container = store.peekRecord('class', 'ember-1.0.0-Container');
+    const container = store.peekRecord('class', 'ember-1.0.0-container');
     assert.equal(
       findAll('.spec-method-list li').length,
       container.get('methods.length')
@@ -32,7 +32,7 @@ module('Acceptance | Class', function (hooks) {
 
   test('lists all the properties on the class page', function (assert) {
     const store = this.owner.lookup('service:store');
-    const container = store.peekRecord('class', 'ember-1.0.0-Container');
+    const container = store.peekRecord('class', 'ember-1.0.0-container');
     assert.equal(
       findAll('.spec-property-list li').length,
       container.get('properties.length')
@@ -41,7 +41,7 @@ module('Acceptance | Class', function (hooks) {
 
   test('lists all the events on the class page', function (assert) {
     const store = this.owner.lookup('service:store');
-    const container = store.peekRecord('class', 'ember-1.0.0-Container');
+    const container = store.peekRecord('class', 'ember-1.0.0-container');
     assert.equal(
       findAll('.spec-event-list li').length,
       container.get('events.length')


### PR DESCRIPTION
for some reason we're requesting the mappings.json file on every initial page load (and not cached in the shoebox). This is in the application afterModel hook so there is no chance that we will ever not make this request, so it's worth just backing the json into the JS bundle to save a request