### PR TITLE
fix: ember-source broken links

### DIFF
--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -3,13 +3,15 @@ import githubMap, { mainDir } from '../utils/github-map';
 
 export function githubLink([project, version, file, line], { isEdit = false }) {
   const isEmberProject = project === 'ember';
-  const majorVersion = parseInt(version.split('.')[0].replace('v', ''), 10);
+  const majorVersion = parseInt(version?.split('.')[0].replace('v', ''), 10);
 
   const baseVersion = `v${version.replace(/^v/, '')}`;
 
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
-    isEmberProject && majorVersion >= 6 ? `${baseVersion}-ember-source` : baseVersion;
+    isEmberProject && majorVersion >= 6
+    ? `${baseVersion}-ember-source`
+     : baseVersion;
 
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(
@@ -31,7 +33,9 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   // 'https://github.com/emberjs/data/tree/v4.10.0/packages/packages/store/addon/-private/record-arrays/identifier-array.ts#L118'
   const fixedFile = file?.replace('../packages/', '../');
 
-  return `https://github.com/${githubMap[project]}/tree/${adjustedVersion}${mainDir(
+  return `https://github.com/${
+    githubMap[project]
+  }/tree/${adjustedVersion}${mainDir(
     project,
     adjustedVersion
   )}${fixedFile}#L${line}`;

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -7,8 +7,7 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
 
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
-    isEmberProject && majorVersion >= 6 ? `${version}-ember-source`
-    : version;
+    isEmberProject && majorVersion >= 6 ? `v${version}-ember-source` : `v${version}`;
 
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -6,8 +6,8 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   const majorVersion = parseInt(version.split('.')[0].replace('v', ''), 10);
 
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
-  const adjustedVersion = isEmberProject && majorVersion >= 6
-    ? `${version}-ember-source`
+  const adjustedVersion =
+    isEmberProject && majorVersion >= 6 ? `${version}-ember-source`
     : version;
 
   if (isEdit) {
@@ -30,7 +30,9 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   // 'https://github.com/emberjs/data/tree/v4.10.0/packages/packages/store/addon/-private/record-arrays/identifier-array.ts#L118'
   const fixedFile = file?.replace('../packages/', '../');
 
-  return `https://github.com/${githubMap[project]}/tree/${adjustedVersion}${mainDir(
+  return `https://github.com/${
+    githubMap[project]
+  }/tree/${adjustedVersion}${mainDir(
     project,
     adjustedVersion
   )}${fixedFile}#L${line}`;

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -5,13 +5,11 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   const isEmberProject = project === 'ember';
   const majorVersion = parseInt(version?.split('.')[0].replace('v', ''), 10);
 
-  const baseVersion = version ? `v${version.replace(/^v/, '')}` : 'main';
-
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
     isEmberProject && majorVersion >= 6
-      ? `${baseVersion}-ember-source`
-      : baseVersion;
+      ? `${version}-ember-source`
+      : version;
 
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(
@@ -35,7 +33,7 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
 
   return `https://github.com/${
     githubMap[project]
-  }/tree/${adjustedVersion}${mainDir(
+  }/tree/v${adjustedVersion}${mainDir(
     project,
     adjustedVersion
   )}${fixedFile}#L${line}`;

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -2,10 +2,15 @@ import { helper } from '@ember/component/helper';
 import githubMap, { mainDir } from '../utils/github-map';
 
 export function githubLink([project, version, file, line], { isEdit = false }) {
+  // Adjust version if it's a `v6.0.x` pattern to match the Git tags
+  const adjustedVersion = version.startsWith('v6.0.')
+    ? `${version}-ember-source`
+    : version;
+
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(
       project,
-      version
+      adjustedVersion
     )}${file}#L${line}`;
   }
 
@@ -22,9 +27,9 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   // 'https://github.com/emberjs/data/tree/v4.10.0/packages/packages/store/addon/-private/record-arrays/identifier-array.ts#L118'
   const fixedFile = file?.replace('../packages/', '../');
 
-  return `https://github.com/${githubMap[project]}/tree/v${version}${mainDir(
+  return `https://github.com/${githubMap[project]}/tree/${adjustedVersion}${mainDir(
     project,
-    version
+    adjustedVersion
   )}${fixedFile}#L${line}`;
 }
 

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -10,8 +10,8 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
     isEmberProject && majorVersion >= 6
-    ? `${baseVersion}-ember-source`
-     : baseVersion;
+      ? `${baseVersion}-ember-source`
+      : baseVersion;
 
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -7,8 +7,7 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
 
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
-    isEmberProject && majorVersion >= 6
-      ? `${version}-ember-source`
+    isEmberProject && majorVersion >= 6 ? `${version}-ember-source`
       : version;
 
   if (isEdit) {

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -7,8 +7,7 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
 
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
-    isEmberProject && majorVersion >= 6 ? `${version}-ember-source`
-      : version;
+    isEmberProject && majorVersion >= 6 ? `${version}-ember-source` : version;
 
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -5,9 +5,11 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   const isEmberProject = project === 'ember';
   const majorVersion = parseInt(version.split('.')[0].replace('v', ''), 10);
 
+  const baseVersion = `v${version.replace(/^v/, '')}`;
+
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =
-    isEmberProject && majorVersion >= 6 ? `v${version}-ember-source` : `v${version}`;
+    isEmberProject && majorVersion >= 6 ? `${baseVersion}-ember-source` : baseVersion;
 
   if (isEdit) {
     return `https://github.com/${githubMap[project]}/edit/release${mainDir(
@@ -29,9 +31,7 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   // 'https://github.com/emberjs/data/tree/v4.10.0/packages/packages/store/addon/-private/record-arrays/identifier-array.ts#L118'
   const fixedFile = file?.replace('../packages/', '../');
 
-  return `https://github.com/${
-    githubMap[project]
-  }/tree/${adjustedVersion}${mainDir(
+  return `https://github.com/${githubMap[project]}/tree/${adjustedVersion}${mainDir(
     project,
     adjustedVersion
   )}${fixedFile}#L${line}`;

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -5,7 +5,7 @@ export function githubLink([project, version, file, line], { isEdit = false }) {
   const isEmberProject = project === 'ember';
   const majorVersion = parseInt(version?.split('.')[0].replace('v', ''), 10);
 
-  const baseVersion = `v${version.replace(/^v/, '')}`;
+  const baseVersion = version ? `v${version.replace(/^v/, '')}` : 'main';
 
   // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
   const adjustedVersion =

--- a/app/helpers/github-link.js
+++ b/app/helpers/github-link.js
@@ -2,8 +2,11 @@ import { helper } from '@ember/component/helper';
 import githubMap, { mainDir } from '../utils/github-map';
 
 export function githubLink([project, version, file, line], { isEdit = false }) {
-  // Adjust version if it's a `v6.0.x` pattern to match the Git tags
-  const adjustedVersion = version.startsWith('v6.0.')
+  const isEmberProject = project === 'ember';
+  const majorVersion = parseInt(version.split('.')[0].replace('v', ''), 10);
+
+  // Check if the project is 'ember' and adjust the tag only if the major version is >= 6 to match the Git tags
+  const adjustedVersion = isEmberProject && majorVersion >= 6
     ? `${version}-ember-source`
     : version;
 

--- a/tests/unit/helpers/github-link-test.js
+++ b/tests/unit/helpers/github-link-test.js
@@ -13,6 +13,17 @@ module('Unit | Helper | github link', function () {
     );
   });
 
+  test('should append "ember-source" to the version for git tags v6 and above', function (assert) {
+    let result = githubLink(
+      ['ember', '6.0.0', 'ember-glimmer/lib/component.js', '35'],
+      {}
+    );
+    assert.equal(
+      result,
+      'https://github.com/emberjs/ember.js/tree/v6.0.0-ember-source/ember-glimmer/lib/component.js#L35'
+    );
+  });
+
   test('should render a github link for ember-data from file info', function (assert) {
     let result = githubLink(
       ['ember-data', '2.10.0', 'addon/-private/adapters/errors.js', '10'],


### PR DESCRIPTION
This PR updates the github-link helper to append -ember-source to the version string for v6.0.x patterns, ensuring correct link generation and preventing broken links

Changes
* Adjusted version logic to append -ember-source for v6.0.x.