### PR TITLE
fix: update GitHub Pages workflow to use Node.js 20 and pnpm 9

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,12 +10,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14'
-      - run: npm install -g npm@7
-      - run: npm install
+          node-version: '20'
+      - run: npm install -g pnpm@9
+      - run: pnpm install
       - run: npx lint-to-the-future output -o lttfOutput --rootUrl ember-api-docs --previous-results https://ember-learn.github.io/ember-api-docs/data.json
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,8 +15,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install -g pnpm@9
-      - run: pnpm install
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+          node-version: 20
+      - run: pnpm i --frozen-lockfile
       - run: npx lint-to-the-future output -o lttfOutput --rootUrl ember-api-docs --previous-results https://ember-learn.github.io/ember-api-docs/data.json
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This PR updates the GitHub Pages workflow to use Node.js 20 and pnpm 9, matching the local setup and CI.yaml to fix deployment failures.