### PR TITLE
Show "on this page" for more resolutions 

### DIFF
--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -413,3 +413,30 @@ table td {
     text-align: center;
   }
 }
+
+/* Overriding ember-styleguide because the on-this-page 
+   is used for index lists of methods and properties and
+   is vital information for the api guides.
+   Ideally we'd also switch to the mobile left nav at
+   around < 1000px but that requires upstream changes.
+*/
+@media (max-width: 80em) {
+  .content-wrapper {
+    gap: 2em;
+    grid-template-columns: minmax(20ch, 80ch) 10em;
+  }
+
+  .on-this-page-wrapper {
+    display: block;
+  }
+}
+
+@media (max-width: 500px) {
+  .content-wrapper {
+    grid-template-columns: minmax(20ch, 80ch);
+  }
+
+  .on-this-page-wrapper {
+    display: block;
+  }
+}


### PR DESCRIPTION
"On this page" along with the method index was only showing on screens > 1280px wide, which means that a lot of users would lose any index of the page on the new redesign. This shows it down to around 500px wide which is a reasonable experience. 

I think it would be preferable to make the mobile left nav show at a larger width and keep the right 'on this page' but that will require upstream changes.